### PR TITLE
Fixing INSTALLATION_INSTRUCTIONS.md for Manual Solution Install

### DIFF
--- a/INSTALLATION_INSTRUCTIONS.md
+++ b/INSTALLATION_INSTRUCTIONS.md
@@ -46,8 +46,8 @@ Please note that flows that begin with "Synchronize files" need to be enabled on
 
 ## Download
 
-1. Download the latest version of the Power CAT Copilot Studio Kit **managed** solution here: <br>
-   [aka.ms/DownloadCopilotStudioKit](https://aka.ms/DownloadCopilotStudioKit) 
+1. Download the latest version of the Power CAT Copilot Studio Kit **managed** solution by going to the latest GitHub Release below: <br>
+   [Power Cat Copilot Studio Kit Latest GitHub Releases](/releases/latest) 
 
 ## Install CopilotStudioAccelerator.zip
 

--- a/INSTALLATION_INSTRUCTIONS.md
+++ b/INSTALLATION_INSTRUCTIONS.md
@@ -47,7 +47,7 @@ Please note that flows that begin with "Synchronize files" need to be enabled on
 ## Download
 
 1. Download the latest version of the Power CAT Copilot Studio Kit **managed** solution by going to the latest GitHub Release below: <br>
-   [Power Cat Copilot Studio Kit Latest GitHub Releases](/releases/latest) 
+   [Power Cat Copilot Studio Kit Latest GitHub Releases](/microsoft/Power-CAT-Copilot-Studio-Kit/releases/latest) 
 
 ## Install CopilotStudioAccelerator.zip
 


### PR DESCRIPTION
Fixing the reference URL to manually install the managed solution file to the latest GitHub Release instead of pointing to the AppSource URL as it does today.