### PR TITLE
Add SECURITY_ROLES.md documentation

### DIFF
--- a/SECURITY_ROLES.md
+++ b/SECURITY_ROLES.md
@@ -264,18 +264,7 @@ The Administrator role provides comprehensive access to manage all aspects of th
 <td>🟢</td>
 </tr>
 <tr>
-<td rowspan="3">Conversation Analyzer</td>
-<td>Agent Compliance</td>
-<td>🟢</td>
-<td>🟢</td>
-<td>🟢</td>
-<td>🟢</td>
-<td>🟢</td>
-<td>🟢</td>
-<td>🟢</td>
-<td>🟢</td>
-</tr>
-<tr>
+<td rowspan="2">Conversation Analyzer</td>
 <td>Conversation Analyzer</td>
 <td>🟢</td>
 <td>🟢</td>
@@ -650,18 +639,7 @@ The Maker role provides access for users who build and test agents, with limited
 <td>🟢</td>
 </tr>
 <tr>
-<td rowspan="3">Conversation Analyzer</td>
-<td>Agent Compliance</td>
-<td>🚫</td>
-<td>🚫</td>
-<td>🚫</td>
-<td>🚫</td>
-<td>🚫</td>
-<td>🚫</td>
-<td>🚫</td>
-<td>🚫</td>
-</tr>
-<tr>
+<td rowspan="2">Conversation Analyzer</td>
 <td>Conversation Analyzer</td>
 <td>🚫</td>
 <td>🚫</td>


### PR DESCRIPTION
This document outlines the security roles and permissions within the Copilot Studio Kit (CSK), including the CSK - Administrator and CSK - Maker roles, their associated permissions, and deprecated legacy roles.