### PR TITLE
feat(copilot-agent): enable Copilot coding agent for landing-page feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/site-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/site-feedback.yml
@@ -11,9 +11,9 @@ body:
 
         **After submitting**, assign this issue to **Copilot** from the right-hand sidebar
         (look for "Copilot" in the assignees dropdown). Copilot will read
-        [`site-src/AGENTS.md`](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/feature/github-pages-agent/site-src/AGENTS.md)
-        for context, make the change in a branch, run the build + smoke test, and open a
-        draft PR targeting `feature/github-pages-agent`. Reviewers will polish and merge.
+        `site-src/AGENTS.md` for context, make the change in a branch, run the build +
+        smoke test, and open a draft PR targeting `feature/github-pages-agent`. Reviewers
+        will polish and merge.
 
         The more specific you are below, the cleaner the PR will be on the first try.
 

--- a/.github/ISSUE_TEMPLATE/site-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/site-feedback.yml
@@ -1,0 +1,104 @@
+name: 🎨 Landing-page feedback
+description: Request a change to the Copilot Agent Kit landing page at https://microsoft.github.io/Power-CAT-Copilot-Studio-Kit/
+title: "[Pages] "
+labels: ["pages", "site-feedback"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the feedback on the [Copilot Agent Kit landing page](https://microsoft.github.io/Power-CAT-Copilot-Studio-Kit/)! 💜
+
+        **After submitting**, assign this issue to **Copilot** from the right-hand sidebar
+        (look for "Copilot" in the assignees dropdown). Copilot will read
+        [`site-src/AGENTS.md`](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/feature/github-pages-agent/site-src/AGENTS.md)
+        for context, make the change in a branch, run the build + smoke test, and open a
+        draft PR targeting `feature/github-pages-agent`. Reviewers will polish and merge.
+
+        The more specific you are below, the cleaner the PR will be on the first try.
+
+  - type: dropdown
+    id: section
+    attributes:
+      label: Which section of the page?
+      description: Roughly where on the page is the change?
+      options:
+        - Hero (top banner with the rainbow headline + stat cards)
+        - Free & Open Source band
+        - Pillars (Quality / Governance / Analytics / Components cards)
+        - Features (the table of 15 features)
+        - Components (cards + Agent Archetype Framework callout)
+        - Get Started (3-step quickstart)
+        - CTA section (purple, near the bottom)
+        - Footer
+        - Header / nav bar
+        - Page-wide (palette, typography, motion, layout)
+        - Not sure / multiple sections
+    validations:
+      required: true
+
+  - type: dropdown
+    id: change_type
+    attributes:
+      label: Type of change
+      options:
+        - Copy / wording change
+        - Color / palette adjustment
+        - Typography (font size, weight, line height)
+        - Layout / spacing
+        - New element (card, callout, button, etc.)
+        - Remove or hide element
+        - Link or URL update
+        - Animation / motion tweak
+        - Accessibility improvement
+        - Bug (something is broken)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What change do you want?
+      description: |
+        Be specific. Reference exact text, colors (hex), or component names where possible.
+        Good: "The 'Pillars' section header is too dark — please lift to about #4A2D52."
+        Less good: "Make it pop more."
+      placeholder: |
+        Currently the … reads as …
+        I'd like it to … instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why? (optional context)
+      description: Background that helps Copilot make a good call — feedback from a customer demo, accessibility need, brand alignment, etc.
+      placeholder: e.g., "Audience read it as too gray during the field call this morning."
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot or reference (optional but recommended)
+      description: Drag-and-drop a screenshot of the current state, or paste a link to a design reference (adoption.microsoft.com, Figma, etc.).
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: How urgent?
+      options:
+        - Nice to have
+        - Soon — would help an upcoming demo
+        - Urgent — visible bug or broken link
+      default: 0
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Quick checks
+      options:
+        - label: I've checked the [current landing page](https://microsoft.github.io/Power-CAT-Copilot-Studio-Kit/) and the change isn't already there.
+          required: true
+        - label: This is feedback on the **landing page**, not the Kit's Power Platform solution components.
+          required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,10 +79,19 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 
 ## Setup-steps environment
 
-The `.github/workflows/copilot-setup-steps.yml` workflow preinstalls Node 20
-and `npm ci`s `agent-review-pipeline/` before any Copilot session starts. If you change
-dependencies in `agent-review-pipeline/package.json`, the cache invalidates automatically
-(keyed on `package-lock.json`).
+The `.github/workflows/copilot-setup-steps.yml` workflow runs before every
+Copilot session and preinstalls Node 20, then conditionally `npm ci`s any
+Node sub-project whose `package-lock.json` is present in the checked-out
+branch:
+
+- **`site-src/`** — landing page (Vite + React + Fluent UI v9). Present on
+  `feature/github-pages-agent`.
+- **`agent-review-pipeline/`** — GitHub Action helper. Present on `main`.
+
+Each step is guarded with `hashFiles(...) != ''` so it's a silent no-op on
+branches where the project isn't present (e.g. `site-src/` on `main` before
+the redesign PR lands). The npm cache is keyed on each project's
+`package-lock.json` so dependency changes automatically invalidate it.
 
 ## When in doubt
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,12 @@ The Power CAT Copilot Studio Kit ships:
 This is the **most common** kind of issue from the team — visual tweaks, copy
 edits, new sections, link updates on the github.io page.
 
-**Read [`site-src/AGENTS.md`](../site-src/AGENTS.md) before touching anything in `site-src/`.**
+> **Note:** `site-src/` and its contents (including `site-src/AGENTS.md`,
+> `site-src/src/`, and `site-src/package.json`) exist only on the
+> `feature/github-pages-agent` branch. These files are **not present on `main`**
+> and will land there via a separate redesign PR.
+
+**Read `site-src/AGENTS.md` (on the `feature/github-pages-agent` branch) before touching anything in `site-src/`.**
 It has the design tokens, the build pipeline, the scroll-reveal pattern, and
 the branching strategy.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,89 @@
+# Copilot instructions — Power CAT Copilot Studio Kit
+
+These instructions guide the GitHub Copilot coding agent (and any human
+contributor reading them) when working in this repository.
+
+## Repository at a glance
+
+The Power CAT Copilot Studio Kit ships:
+
+- **Power Platform solution files** (top-level folders) — the actual Kit
+  components: validation framework, library components, governance tooling,
+  agent inventory, etc. These get packaged and imported into customer
+  environments.
+- **A GitHub Pages landing page** at https://microsoft.github.io/Power-CAT-Copilot-Studio-Kit/
+  built from `site-src/` (Vite + React 19 + Fluent UI v9 + TypeScript) and
+  deployed from `docs/` on the `feature/github-pages-agent` branch.
+- **Documentation** under `docs/` (the landing-page assets) and other top-level
+  `.md` files.
+
+## Most tasks fall into one of these buckets
+
+### 1. Landing-page changes (`site-src/`)
+
+This is the **most common** kind of issue from the team — visual tweaks, copy
+edits, new sections, link updates on the github.io page.
+
+**Read [`site-src/AGENTS.md`](../site-src/AGENTS.md) before touching anything in `site-src/`.**
+It has the design tokens, the build pipeline, the scroll-reveal pattern, and
+the branching strategy.
+
+Key rules for landing-page work:
+
+- Edit source in `site-src/src/` (most often `theme.ts`, `App.tsx`, `features.ts`)
+- Build with `cd site-src && npm ci && npm run build`
+- The build writes into `../docs/` (committed — this is the Pages source)
+- Commit **both** source AND rebuilt `docs/` artifacts in the same commit
+- **Open the PR against the `feature/github-pages-agent` branch**, NOT `main`
+- The Pages deploy workflow only fires on pushes to `feature/github-pages-agent`
+  that touch `docs/**`
+
+### 2. Solution / component changes
+
+Power Platform solution work happens at the top level (`Solutions/`,
+`CopilotStudioKit/`, etc.). These typically require manual export from
+maker.powerapps.com or pac CLI — Copilot can review diffs and update docs but
+should not invent solution XML by hand. If an issue asks for a solution
+change, propose a plan and request human confirmation before unpacking
+solution files.
+
+### 3. Docs / README updates
+
+Standard markdown edits. No build step. Open PRs against `main`.
+
+## Branching strategy
+
+| Branch | Purpose |
+|---|---|
+| `main` | Default. Solution files, top-level docs, this instructions file, the `copilot-setup-steps.yml` workflow. |
+| `feature/github-pages-agent` | GitHub Pages source. `docs/**` pushes here trigger deploy. **Target this branch for landing-page PRs.** |
+| Topic branches | Always branch off the appropriate base above. Use kebab-case names. |
+
+## Commit message conventions
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+`feat:`, `fix:`, `style:`, `docs:`, `refactor:`, `chore:`, `ci:`.
+
+Scope landing-page commits with `(pages)`: e.g., `feat(pages): lighten hero palette`.
+
+Always include the trailer:
+
+```
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+## Setup-steps environment
+
+The `.github/workflows/copilot-setup-steps.yml` workflow preinstalls Node 20
+and `npm ci`s `site-src/` before any Copilot session starts. If you change
+dependencies in `site-src/package.json`, the cache invalidates automatically
+(keyed on `package-lock.json`).
+
+## When in doubt
+
+- Visual / UX questions → mirror https://adoption.microsoft.com/en-us/copilot/
+- Brand color → `#833D91` (purple); the six-stop rainbow is decorative
+- Component library → built on the [Agent Archetype Framework](https://learn.microsoft.com/en-us/agents/agent-archetypes/framework-apply)
+  3Cs model (Categories / Capabilities / Components)
+- Need more context on the kit overall → see the top-level [README.md](../README.md)
+  and https://learn.microsoft.com/en-us/microsoft-copilot-studio/guidance/copilot-studio-kit-overview

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,8 +75,8 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 ## Setup-steps environment
 
 The `.github/workflows/copilot-setup-steps.yml` workflow preinstalls Node 20
-and `npm ci`s `site-src/` before any Copilot session starts. If you change
-dependencies in `site-src/package.json`, the cache invalidates automatically
+and `npm ci`s `agent-review-pipeline/` before any Copilot session starts. If you change
+dependencies in `agent-review-pipeline/package.json`, the cache invalidates automatically
 (keyed on `package-lock.json`).
 
 ## When in doubt

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,45 @@
+name: "Copilot Setup Steps"
+
+# Triggered automatically on changes to this file (so you can validate the
+# config from the Actions tab) and runs before every Copilot coding agent
+# session — preinstalling tools so the agent boots into a ready environment
+# instead of trial-and-erroring its way through dependency installation.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # MUST be named `copilot-setup-steps` — Copilot looks for this exact job name.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      # The landing page (site-src/) is the most common target of Copilot
+      # tasks today. Set up Node + cache npm so rebuilds are fast and reliable.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: site-src/package-lock.json
+
+      - name: Install site-src dependencies
+        working-directory: site-src
+        run: npm ci
+
+      # Validate the build works in the runner. If this step fails on the
+      # default branch, dependencies are broken and Copilot tasks will fail.
+      - name: Smoke-build site-src
+        working-directory: site-src
+        run: npm run build

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,7 +27,10 @@ jobs:
 
       # The agent-review-pipeline/ is the Node.js project in this repo.
       # Set up Node + cache npm so rebuilds are fast and reliable.
+      # Steps are guarded so they no-op when agent-review-pipeline/ is absent
+      # (e.g. on branches that predate that directory).
       - name: Set up Node.js
+        if: hashFiles('agent-review-pipeline/package-lock.json') != ''
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -35,11 +38,13 @@ jobs:
           cache-dependency-path: agent-review-pipeline/package-lock.json
 
       - name: Install agent-review-pipeline dependencies
+        if: hashFiles('agent-review-pipeline/package-lock.json') != ''
         working-directory: agent-review-pipeline
         run: npm ci
 
       # Validate the build works in the runner. If this step fails on the
       # default branch, dependencies are broken and Copilot tasks will fail.
       - name: Smoke-build agent-review-pipeline
+        if: hashFiles('agent-review-pipeline/package-lock.json') != ''
         working-directory: agent-review-pipeline
         run: npm run build

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,11 +25,39 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # The agent-review-pipeline/ is the Node.js project in this repo.
-      # Set up Node + cache npm so rebuilds are fast and reliable.
-      # Steps are guarded so they no-op when agent-review-pipeline/ is absent
-      # (e.g. on branches that predate that directory).
-      - name: Set up Node.js
+      # Set up Node 20 unconditionally — both Node sub-projects in this repo
+      # (agent-review-pipeline/ on main, site-src/ on feature/github-pages-agent)
+      # need it, and the agent may also use Node for ad-hoc tooling.
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # ---- site-src/ (landing page — Vite + React + Fluent UI v9) ----
+      # Present on feature/github-pages-agent (the GitHub Pages source branch).
+      # Guarded with hashFiles so the step is a silent no-op on branches where
+      # site-src/ doesn't exist yet (e.g. main, before the redesign PR lands).
+      - name: Cache site-src npm
+        if: hashFiles('site-src/package-lock.json') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: site-src/package-lock.json
+
+      - name: Install site-src dependencies
+        if: hashFiles('site-src/package-lock.json') != ''
+        working-directory: site-src
+        run: npm ci
+
+      - name: Smoke-build site-src
+        if: hashFiles('site-src/package-lock.json') != ''
+        working-directory: site-src
+        run: npm run build
+
+      # ---- agent-review-pipeline/ (GitHub Action — TypeScript) ----
+      # Present on main. Same hashFiles guard pattern so it's a no-op when absent.
+      - name: Cache agent-review-pipeline npm
         if: hashFiles('agent-review-pipeline/package-lock.json') != ''
         uses: actions/setup-node@v4
         with:
@@ -42,8 +70,6 @@ jobs:
         working-directory: agent-review-pipeline
         run: npm ci
 
-      # Validate the build works in the runner. If this step fails on the
-      # default branch, dependencies are broken and Copilot tasks will fail.
       - name: Smoke-build agent-review-pipeline
         if: hashFiles('agent-review-pipeline/package-lock.json') != ''
         working-directory: agent-review-pipeline

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       # The agent-review-pipeline/ is the Node.js project in this repo.
       # Set up Node + cache npm so rebuilds are fast and reliable.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,21 +25,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      # The landing page (site-src/) is the most common target of Copilot
-      # tasks today. Set up Node + cache npm so rebuilds are fast and reliable.
+      # The agent-review-pipeline/ is the Node.js project in this repo.
+      # Set up Node + cache npm so rebuilds are fast and reliable.
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
-          cache-dependency-path: site-src/package-lock.json
+          cache-dependency-path: agent-review-pipeline/package-lock.json
 
-      - name: Install site-src dependencies
-        working-directory: site-src
+      - name: Install agent-review-pipeline dependencies
+        working-directory: agent-review-pipeline
         run: npm ci
 
       # Validate the build works in the runner. If this step fails on the
       # default branch, dependencies are broken and Copilot tasks will fail.
-      - name: Smoke-build site-src
-        working-directory: site-src
+      - name: Smoke-build agent-review-pipeline
+        working-directory: agent-review-pipeline
         run: npm run build

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["feature/github-pages-agent"]
     paths:
       - 'docs/**'
   workflow_dispatch:


### PR DESCRIPTION
Enables the **GitHub Copilot cloud agent** to pick up landing-page feedback issues from the team and ship PRs automatically.

## What this adds
1. **`.github/workflows/copilot-setup-steps.yml`** — preinstalls Node 20 + `npm ci` in `site-src/` before each Copilot session, so the agent boots into a working dev env. Includes a smoke `npm run build` step so the workflow itself fails fast if deps are broken on `main`.
2. **`.github/copilot-instructions.md`** — repo-wide context: structure, branching strategy (PRs against `feature/github-pages-agent` for landing-page work, `main` for everything else), commit conventions, pointer to the more detailed `site-src/AGENTS.md` (which lands on the redesign PR).
3. **`.github/ISSUE_TEMPLATE/site-feedback.yml`** — structured issue form: section selector, change-type dropdown, description, rationale, screenshot, priority. Submitters then assign Copilot to trigger the agent.

## Team workflow this unlocks
1. Team member opens https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/issues/new?template=site-feedback.yml
2. Fills the form, submits, assigns @Copilot
3. Copilot reads `copilot-instructions.md` + `site-src/AGENTS.md`, branches off `feature/github-pages-agent`, edits `site-src/`, rebuilds `docs/`, opens a draft PR
4. Maintainer reviews + merges; Pages auto-deploys

## Prerequisite
The Copilot coding agent must be **enabled at the repo or org level** in repo Settings → Code & automation → Copilot. If it's not yet enabled, ping the org admin.

## Note on landing on `main`
The `copilot-setup-steps.yml` workflow only triggers when present on the default branch — so this PR is a prerequisite for any landing-page feedback flow.