### PR TITLE
fix: update Pages deploy trigger from feature branch to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: ["feature/github-pages-agent"]
+    branches: ["main"]
     paths:
       - 'docs/**'
   workflow_dispatch:


### PR DESCRIPTION
The deploy-pages.yml workflow was configured to trigger on pushes to 'feature/github-pages-agent' instead of 'main'. Since the .ics calendar files now live in docs/calendar/ on main, Pages was never redeployed, causing 404 errors for the calendar download links in OFFICEHOURS.md.