### PR TITLE
Rebrand/copilot agent kit

### DIFF
--- a/ADAPTIVE_CARDS_GALLERY.md
+++ b/ADAPTIVE_CARDS_GALLERY.md
@@ -1,7 +1,7 @@
 # Adaptive cards gallery
 ## Setup Note
 
-To get the Adaptive cards gallery working after you install the Copilot Studio Kit solution, you will need to go to the ````Adaptive Card Gallery```` Agent that was installed in the solution file.  
+To get the Adaptive cards gallery working after you install the Copilot Agent Kit solution, you will need to go to the ````Adaptive Card Gallery```` Agent that was installed in the solution file.  
 
 * Open Copilot Studio in your current environment
 * Open the ````Adaptive Card Gallery```` Agent that was deployed in the solution file
@@ -29,7 +29,7 @@ Each sample adaptive card comes with a template and sample data. Adaptive cards 
 ![adaptivecards2](https://github.com/user-attachments/assets/d4e7ca66-2e7c-497c-94e8-0695e12253dd)
 
 > [!NOTE]
-> By default, emulator is used to preview the adaptive cards. To preview the adaptive cards using a real Copilot Studio webchat, publish the "**Adaptive Card Gallery**"-agent that ships with Copilot Studio Kit, and set the environment variable **cat_AgentTokenEndpoint** to its Token Endpoint. The token endpoint of Copilot Studio custom agent can be copied from Channels -> Mobile app.
+> By default, emulator is used to preview the adaptive cards. To preview the adaptive cards using a real Copilot Studio webchat, publish the "**Adaptive Card Gallery**"-agent that ships with Copilot Agent Kit, and set the environment variable **cat_AgentTokenEndpoint** to its Token Endpoint. The token endpoint of Copilot Studio custom agent can be copied from Channels -> Mobile app.
 
 
 Back to the [landing page](./README.md#power-cat-copilot-studio-kit)

--- a/AGENTREVIEWTOOL_REFERENCE_GUIDE.md
+++ b/AGENTREVIEWTOOL_REFERENCE_GUIDE.md
@@ -653,4 +653,4 @@ Yes. Use the "Export All" button in the agent grid toolbar to generate an Excel 
 
 ---
 
-*Documentation version: April 2026. For the latest changes, see the [Power CAT Copilot Studio Kit GitHub repository](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit).*
+*Documentation version: April 2026. For the latest changes, see the [Copilot Agent Kit GitHub repository](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit).*

--- a/AGENT_DEBUGGER.md
+++ b/AGENT_DEBUGGER.md
@@ -78,7 +78,7 @@ See the Agent Inventory documentation for full setup instructions:
 
 ### 2. Security role and connection permissions
 
-The user must have the **CSK - Administrator** or **System Administrator** security role within the kit for this feature to be accessible.
+The user must have the **CAK - Administrator** or **System Administrator** security role within the kit for this feature to be accessible.
 
 The **signed in user** used by the app must have **Read** access to the following tables in the target environment:
 
@@ -445,7 +445,7 @@ Use this when:
 **Cause:** Missing roles or permissions in one or both environments.
 
 **Resolution:**
-1. In the **kit environment**, the user must have the **CSK - Administrator** or **System Administrator** role to access Agent Debugger.
+1. In the **kit environment**, the user must have the **CAK - Administrator** or **System Administrator** role to access Agent Debugger.
 2. In the **target environment** where the agent resides, the signed-in user must have sufficient access to read the `conversationtranscripts`, `bot`, and `botcomponents` tables.
 
 

--- a/AGENT_INSIGHTS_HUB.md
+++ b/AGENT_INSIGHTS_HUB.md
@@ -60,12 +60,12 @@ Before using Agent Insights Hub, ensure the following are in place:
 
 3. **Azure App Registration** — An Azure AD app must be registered with access to the Application Insights telemetry data. Follow the setup guide: [Enable Application Insights Support](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/main/ENABLE-APPINSIGHTS.md#enable-application-insights-support).
 
-4. **Security role assignment** — User must be assigned the **CSK - Administrator** role to access this feature.
+4. **Security role assignment** — User must be assigned the **CAK - Administrator** role to access this feature.
    
-5. **App sharing** — The owner of the Copilot Studio Kit code app (or the System Administrator who installed kit) must share the app with other users on their team. Follow these steps:
+5. **App sharing** — The owner of the Copilot Agent Kit code app (or the System Administrator who installed kit) must share the app with other users on their team. Follow these steps:
    1. Go to [make.powerapps.com](https://make.powerapps.com/)
    2. Click **Apps** in the left navigation
-   3. Search for **Copilot Studio Kit** and locate the one with type **Code** (not the Model-driven app)
+   3. Search for **Copilot Agent Kit** and locate the one with type **Code** (not the Model-driven app)
    4. Click the **three dots (...)** menu next to the app
    5. Select **Share**
    6. Search for and add the users or security groups who need access
@@ -560,7 +560,7 @@ Key highlights:
 
 ### 9.2 How to Access
 
-1. Open the **Agent Insights Hub** in the Copilot Studio Kit app.
+1. Open the **Agent Insights Hub** in the Copilot Agent Kit app.
 2. Select the **Build dashboard & forecast** button in the header area.
 3. The feature opens in a full-screen view with three tabs: **Dashboards**, **Forecast**, and **Metrics**.
 4. To return to the Agent Insights Hub, select the **back arrow** button in the top-left corner.

--- a/AGENT_INVENTORY.md
+++ b/AGENT_INVENTORY.md
@@ -2,7 +2,7 @@
 
 ## Agent Inventory overview
 
-Copilot Studio Kit Agent Inventory feature can be used to easily get a tenant-wide visibility to all the **custom agents** and **declarative agents** in the organization, across environments. Agent inventory data includes basic metadata like creation times, publish status and authentication mode, as well as information on the feature usage like knowledge sources used, usage of prompts, orchestration type and more.
+Copilot Agent Kit Agent Inventory feature can be used to easily get a tenant-wide visibility to all the **custom agents** and **declarative agents** in the organization, across environments. Agent inventory data includes basic metadata like creation times, publish status and authentication mode, as well as information on the feature usage like knowledge sources used, usage of prompts, orchestration type and more.
 
 ## Dashboard
 
@@ -22,7 +22,7 @@ knowledge sources and more.
 
 > **Disclaimer:** The usage percentages shown here depend on the environments for which the user has System Administrator access.
 
-![Copilot Studio Kit - Agent Details](https://github.com/user-attachments/assets/5e4e4344-2b0b-4ee6-91d9-7bc87f047fbe)
+![Copilot Agent Kit - Agent Details](https://github.com/user-attachments/assets/5e4e4344-2b0b-4ee6-91d9-7bc87f047fbe)
 
 
 ## List view
@@ -38,12 +38,12 @@ You can view usage details for your agent over the past 180 days in **Agent Inve
 
 Before using the usage metrics feature:
 
-1. **Install** the **Copilot Studio Kit main solution**.
+1. **Install** the **Copilot Agent Kit main solution**.
 2. **Ensure** that the connector **HTTP with Microsoft Entra ID (preauthorized)** is allowed in your environment.
 
 ### Installation Instructions 
 
-To enable usage metrics on top of the Copilot Studio Kit main solution, you must **import the `AgentInventoryUsage` solution**, available in the **Latest release Assets directory**.
+To enable usage metrics on top of the Copilot Agent Kit main solution, you must **import the `AgentInventoryUsage` solution**, available in the **Latest release Assets directory**.
 
 During the import process, create a connection using the licensing host URL: https://licensing.powerplatform.microsoft.com/
 
@@ -61,7 +61,7 @@ Usage data in the **Agent Details** table is refreshed in two ways:
 In the **Agent Inventory Dashboard**, review the **Agents** grid. 
 If the **Total Usage/Month** field contains a value, the **Usage Metrics** section will be displayed on the **Agent Details** page.
 
-![Copilot Studio Kit - Agent Details With Usage](https://github.com/user-attachments/assets/197f0539-016c-4c26-8439-e2382fab9349)
+![Copilot Agent Kit - Agent Details With Usage](https://github.com/user-attachments/assets/197f0539-016c-4c26-8439-e2382fab9349)
 
 
 > [!NOTE]
@@ -76,7 +76,7 @@ The data collection process is controlled by the **Enable One Inventory** enviro
 When **Enable One Inventory** is set to **Yes**, the process uses One Inventory data:
 
 1. Agent data is retrieved from One Inventory through the Power Platform Admin Center.
-2. Environments are listed using the **Copilot Studio Kit - Power Platform for Admins V2** connector.
+2. Environments are listed using the **Copilot Agent Kit - Power Platform for Admins V2** connector.
 3. The One Inventory agent data is combined with the environments list to construct environment details.
 4. For each environment, agent details are loaded into Agent Inventory by merging agents fetched from the environment with the corresponding One Inventory data.
 
@@ -84,11 +84,11 @@ When **Enable One Inventory** is set to **Yes**, the process uses One Inventory 
 
 When **Enable One Inventory** is set to **No**, the process follows the standard data collection approach:
 
-1. All environments are listed using the **Copilot Studio Kit - Power Platform for Admins V1** connector.
+1. All environments are listed using the **Copilot Agent Kit - Power Platform for Admins V1** connector.
 2. Agents are fetched for each environment.
 3. Agent data is loaded into Agent Inventory.
 
-In both modes, the **Copilot Studio Kit - Dataverse** connector connects to each environment to gather detailed agent information (metadata, feature usage, configuration) — but only where the configured account has **system admin access**.
+In both modes, the **Copilot Agent Kit - Dataverse** connector connects to each environment to gather detailed agent information (metadata, feature usage, configuration) — but only where the configured account has **system admin access**.
 
 For full tenant-wide visibility, the connection references must be configured with an account that has the **Power Platform admin role** and to view all the features need to have **system admin level permission** to all environments. Other accounts can be used, but the inventory will be limited to the environments the user has system admin access to.
 

--- a/AGENT_INVENTORY_DATA_SOURCE.md
+++ b/AGENT_INVENTORY_DATA_SOURCE.md
@@ -3,7 +3,7 @@
 Overview
 --------
 
-This document is the authoritative reference for the Agent Details table (Dataverse) that powers the Agent Inventory page in Copilot Studio Kit. It lists every field, the Dataverse source or detection rule, version/maturity, and a concise description for downstream consumers.
+This document is the authoritative reference for the Agent Details table (Dataverse) that powers the Agent Inventory page in Copilot Agent Kit. It lists every field, the Dataverse source or detection rule, version/maturity, and a concise description for downstream consumers.
 
 Audience
 --------
@@ -163,7 +163,7 @@ Below are concise detection rules for each derived or boolean field (refer to lo
 - Environment Url (`cat_environmenturl`): Power Platform for Admins V2 — `Retrieve a list of environments` output: instance URL.
 - Is Transcript Available (`cat_istranscriptavailablecode`): true when records exist for the agent in `conversationtranscript`.
 - Agent Created By ADID (`cat_agentcreatedbyadid`): `systemuser` table → ADID or Azure Object ID of the user who created the agent.
-- Agent Test Configured (`cat_agenttestconfiguredcode`): true when test run exists in Agent Test Run and test case exists in Agent Test Case table for the agent (Copilot Studio Kit test automation).
+- Agent Test Configured (`cat_agenttestconfiguredcode`): true when test run exists in Agent Test Run and test case exists in Agent Test Case table for the agent (Copilot Agent Kit test automation).
 - Last Usage Date (`cat_lastusagedate`): last usage date from usage metrics in Power Platform Admin Center.
 - Last Usage Feature (`cat_lastusagefeature`): last usage feature from usage metrics in Power Platform Admin Center.
 - Template (`cat_template`): `bot` table → identifies template and version used for bot default content.

--- a/AGENT_LIBRARY.md
+++ b/AGENT_LIBRARY.md
@@ -1,6 +1,6 @@
 # Agent Library
 
-The Agent Library is a centralized hub within the Copilot Studio Kit that helps **Admins** and **Makers** discover, install, and manage agent templates and reusable components. It brings together three types of content in a single unified gallery:
+The Agent Library is a centralized hub within the Copilot Agent Kit that helps **Admins** and **Makers** discover, install, and manage agent templates and reusable components. It brings together three types of content in a single unified gallery:
 
 - **System templates** — Provided by Microsoft. Ready-to-use agent templates that ship with the Kit and are available out of the box. System template cards are visually distinguished with a **"System"** chip on the gallery card.
 - **Custom templates** — Bring your own templates. Organization-specific agent templates authored by admins and stored in Dataverse. Custom template cards are visually distinguished with a **"Custom"** chip on the gallery card.
@@ -9,7 +9,7 @@ The Agent Library is a centralized hub within the Copilot Studio Kit that helps 
 Instead of building agents from scratch, you can browse the combined catalog, install templates directly into your environment, and extend them with reusable components. **Admins** additionally get a full authoring surface to create, edit, publish/unpublish, and delete custom templates. **Makers** see a read-only view scoped to published custom templates only.
 
 > [!NOTE]
-> The Agent Library is available starting with the **April 2026 release** of the Copilot Studio Kit. Custom template management (bring your own templates) was introduced in the **mid-June 2026 release**. Make sure you are running the latest version to access all features.
+> The Agent Library is available starting with the **April 2026 release** of the Copilot Agent Kit. Custom template management (bring your own templates) was introduced in the **mid-June 2026 release**. Make sure you are running the latest version to access all features.
 
 ---
 
@@ -17,9 +17,9 @@ Instead of building agents from scratch, you can browse the combined catalog, in
 
 Before using the Agent Library, make sure you have:
 
-- Installed **Copilot Studio Kit** and configured in your Power Platform environment.
-- A **CSK - Maker** security role assigned in the Copilot Studio Kit to browse and install templates.
-- A **CSK - Admin** security role assigned to create, edit, publish/unpublish, and delete custom templates.
+- Installed **Copilot Agent Kit** and configured in your Power Platform environment.
+- A **CAK - Maker** security role assigned in the Copilot Agent Kit to browse and install templates.
+- A **CAK - Admin** security role assigned to create, edit, publish/unpublish, and delete custom templates.
 - A Power Platform environment with **Copilot Studio** enabled.
 
 ### Role Capabilities
@@ -37,7 +37,7 @@ Before using the Agent Library, make sure you have:
 
 ## Agent Library Experience
 
-The Agent Library is accessible from the left navigation in the Copilot Studio Kit under the **Productivity** section. The Agent Library dashboard provides three tabs: **All**, **Templates**, and **Components**.
+The Agent Library is accessible from the left navigation in the Copilot Agent Kit under the **Productivity** section. The Agent Library dashboard provides three tabs: **All**, **Templates**, and **Components**.
 
 ### All Tab (Default)
 
@@ -86,11 +86,11 @@ The following templates are included out of the box:
 
 Custom Agent type templates are pre-built Copilot Studio agents packaged as Power Platform solutions. They provide a fully functional starting point that you can customize with your own topics, knowledge sources, and components.
 
-##### Install from Copilot Studio Kit (Recommended)
+##### Install from Copilot Agent Kit (Recommended)
 
-If you are running the Copilot Studio Kit, you can browse and install custom agent templates directly from the Agent Library.
+If you are running the Copilot Agent Kit, you can browse and install custom agent templates directly from the Agent Library.
 
-1. In the Copilot Studio Kit, navigate to **Agent Library** in the left navigation.
+1. In the Copilot Agent Kit, navigate to **Agent Library** in the left navigation.
 2. Select the **Templates** tab.
 3. Browse or search for the custom agent template you want to install.
 4. Select a template card to open the template details dialog.
@@ -260,7 +260,7 @@ Admins can extend the Agent Library by authoring **custom templates** — organi
 ![Agent Library — Admin View with Custom Templates](media/agent-library/csk-admin-with-custom-templates.png)
 
 > [!NOTE]
-> Custom template management is available only to users with the **CSK - Admin** security role. Makers see published custom templates in the gallery but cannot create, edit, or delete them.
+> Custom template management is available only to users with the **CAK - Admin** security role. Makers see published custom templates in the gallery but cannot create, edit, or delete them.
 
 ##### Creating a Custom Template
 
@@ -351,9 +351,9 @@ The Components tab filters the catalog to show **only reusable components** that
 
 There are two ways to install components.
 
-##### Option A — Install from the Copilot Studio Kit (Recommended)
+##### Option A — Install from the Copilot Agent Kit (Recommended)
 
-1. In the Copilot Studio Kit, navigate to the **Agent Library** and select the **Components** tab.
+1. In the Copilot Agent Kit, navigate to the **Agent Library** and select the **Components** tab.
 2. Select a component card to open the component details dialog.
 
 ![Component Details](media/agent-library/components-details.png)
@@ -371,7 +371,7 @@ There are two ways to install components.
 
 ##### Option B — Manual Import via Power Apps
 
-Use this option to import the component in other environment where Copilot Studio Kit is not installed, or if you downloaded the `.zip` file and need to import it manually.
+Use this option to import the component in other environment where Copilot Agent Kit is not installed, or if you downloaded the `.zip` file and need to import it manually.
 
 1. Download the `.zip` file that contains the component solution:
    - **From the Agent Library** — Open the component details dialog and select **Download**.
@@ -431,7 +431,7 @@ This section walks you through the complete workflow of discovering a template, 
 
 ### Step 1: Discover a Template
 
-1. Open the Copilot Studio Kit and navigate to the **Agent Library**.
+1. Open the Copilot Agent Kit and navigate to the **Agent Library**.
 2. Use the **All** tab to see what templates and components are available.
 3. Switch to the **Templates** tab to browse the catalog.
 4. Use search and category filters to find a template that matches your scenario.
@@ -502,7 +502,7 @@ This section walks you through the complete workflow of discovering a template, 
 
 - **One instance per environment** — Components are shared across all agents in an environment. Changes to a component affect every agent that uses it.
 - **Test in a development environment first** — Install and validate templates in a non-production environment before promoting to production.
-- **Keep solutions up to date** — Check the [Copilot Studio Kit releases](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/releases) for new templates, components, and improvements.
+- **Keep solutions up to date** — Check the [Copilot Agent Kit releases](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/releases) for new templates, components, and improvements.
 
 ### Custom Template Management (Admin)
 
@@ -516,8 +516,8 @@ This section walks you through the complete workflow of discovering a template, 
 
 ## Related Content
 
-- [Copilot Studio Kit overview](https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-overview)
-- [Install Copilot Studio Kit](https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-install)
+- [Copilot Agent Kit overview](https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-overview)
+- [Install Copilot Agent Kit](https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-install)
 - [Component Library documentation](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/main/COMPONENT_LIBRARY.md)
 - [Create and share reusable component collections](https://learn.microsoft.com/microsoft-copilot-studio/authoring-export-import-copilot-components)
 - [Create and manage solutions in Copilot Studio](https://learn.microsoft.com/microsoft-copilot-studio/authoring-solutions-overview)

--- a/ALLOW_CONNECTION_POPUP.md
+++ b/ALLOW_CONNECTION_POPUP.md
@@ -6,7 +6,7 @@ When testing Copilot Studio agents that integrate with external data sources lik
 
 
 
-**Challenge:** How do users execute test cases within Copilot Studio Kit to handle this authorization flow and test agent responses that require connector permissions?
+**Challenge:** How do users execute test cases within Copilot Agent Kit to handle this authorization flow and test agent responses that require connector permissions?
 
 ---
 

--- a/ANALYZE_TEST_RESULTS.md
+++ b/ANALYZE_TEST_RESULTS.md
@@ -1,4 +1,4 @@
-# Analyzing test results in Power CAT Copilot Studio Kit
+# Analyzing test results in Copilot Agent Kit
 
 ## Test run details
 

--- a/AUTOMATED_TESTING.md
+++ b/AUTOMATED_TESTING.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This feature allows users to automate the testing and deployment of Copilot Studio custom agents using Power Platform Pipelines. The goal is to ensure that agents are automatically validated through test runs before they are deployed to target environments (production). By integrating Power Automate flows with Dataverse and the Copilot Studio Kit, this approach introduces a quality gate into the deployment process. Only agents that pass the required amount of test cases are allowed to proceed, ensuring higher reliability and reducing manual intervention. This method supports continuous delivery practices and enhances the overall governance of the deployment lifecycle .
+This feature allows users to automate the testing and deployment of Copilot Studio custom agents using Power Platform Pipelines. The goal is to ensure that agents are automatically validated through test runs before they are deployed to target environments (production). By integrating Power Automate flows with Dataverse and the Copilot Agent Kit, this approach introduces a quality gate into the deployment process. Only agents that pass the required amount of test cases are allowed to proceed, ensuring higher reliability and reducing manual intervention. This method supports continuous delivery practices and enhances the overall governance of the deployment lifecycle .
 
 ## What it allows users to do
 

--- a/COMPLIANCE_HUB.md
+++ b/COMPLIANCE_HUB.md
@@ -18,7 +18,7 @@ The Compliance Hub enables organizations using Copilot Studio to balance innovat
 
 Before setting up the Compliance Hub, ensure you have:
 
-- **Copilot Studio Kit prerequisites**: All [prerequisites for the Copilot Studio Kit](PREREQUISITES.md)
+- **Copilot Agent Kit prerequisites**: All [prerequisites for the Copilot Agent Kit](PREREQUISITES.md)
 - **Permissions (for admin)**: 
   - System Administrator role in the target environment
   - Ability to create and configure cloud flows
@@ -63,11 +63,11 @@ Any user who has created a Copilot Studio agent in the organization's tenant. Th
 
 ## Get started
 
-Setup and configure the governance components using the Copilot Studio Kit setup wizard.
+Setup and configure the governance components using the Copilot Agent Kit setup wizard.
 
 **Estimated time to complete**: 20 minutes (excluding prerequisite installations)
 
-1. Install and launch the Copilot Studio Kit. Follow the [installation instructions](./INSTALLATION_INSTRUCTIONS.md) and [prerequisites](./PREREQUISITES.md) for the essential install steps to install the base solution and [agent inventory](./AGENT_INVENTORY.md) before setting up the compliance components.
+1. Install and launch the Copilot Agent Kit. Follow the [installation instructions](./INSTALLATION_INSTRUCTIONS.md) and [prerequisites](./PREREQUISITES.md) for the essential install steps to install the base solution and [agent inventory](./AGENT_INVENTORY.md) before setting up the compliance components.
 
 1. Run the **setup wizard**.
 
@@ -81,7 +81,7 @@ Setup and configure the governance components using the Copilot Studio Kit setup
 
     | Display Name| Description| Example |
     |--------------------------------------------|-----------------------------------------------------------------------------|------------------------|
-    | App ID | Unique identifier for the Copilot Studio Kit application | `12345678-1234-1234-1234-123456789abc` |
+    | App ID | Unique identifier for the Copilot Agent Kit application | `12345678-1234-1234-1234-123456789abc` |
     | Compliance Admin Group ID | Microsoft Entra ID (Azure AD) security group ID for compliance administrators | `87654321-4321-4321-4321-cba987654321` | 
     | Instance Url | URL of the environment instance | `https://orgname.crm.dynamics.com` |
     | Maker Team ID | Group ID for makers in the organization | `12345678-1234-1234-1234-123456789abc` |
@@ -153,7 +153,7 @@ Governance policies in compliance hub are configured by:
 The following components can be configured to define and enforce the compliance policies that best define your organization's requirements.
 
 ### Compliance thresholds (`Threshold Config` table)
-This is how 'violations' are defined in compliance hub. Each row in the `Threshold Config` table must be associated with a specific agent attribute (aka property/column) and a specific value. It is designed to be fully customizable within the scope of the agent components represented in Copilot Studio Kit's `Agent Details` custom table properties.
+This is how 'violations' are defined in compliance hub. Each row in the `Threshold Config` table must be associated with a specific agent attribute (aka property/column) and a specific value. It is designed to be fully customizable within the scope of the agent components represented in Copilot Agent Kit's `Agent Details` custom table properties.
 
 ![Threshold Configuration Table](./media/ch_1.png)
 *Figure 2: Default configurations for Threshold Config table showing filter columns, operators, and risk levels*
@@ -365,7 +365,7 @@ A: A quarantined agent is disabled and cannot be accessed by end users. However,
 
 - Compliance re-evaluation occurs daily (typically runs overnight)
 - Manually trigger a compliance scan from the Compliance Hub dashboard
-- Verify remediation changes are saved and published in Copilot Studio Kit Inventory
+- Verify remediation changes are saved and published in Copilot Agent Kit Inventory
 - Check the case timeline for evaluation history
 
 **Issue: Filter operators not working as expected**

--- a/COMPONENT_LIBRARY.md
+++ b/COMPONENT_LIBRARY.md
@@ -1,8 +1,8 @@
-# Copilot Studio Kit Component Library
+# Copilot Agent Kit Component Library
 
 The Component Library provides a set of reusable, pre-built components for Microsoft Copilot Studio. Each component is packaged as its own [component collection](https://learn.microsoft.com/microsoft-copilot-studio/authoring-export-import-copilot-components), so you can install only the components you need. Import the solution into your environment, add the component collections you want to your agent, and use your agent’s instructions to tell the agent how to use them, or directly reference the prompts and flows to enhance your topic.
 
-![Component Library in the Copilot Studio Kit](docs/images/component-library.png)
+![Component Library in the Copilot Agent Kit](docs/images/component-library.png)
 
 > [!NOTE]
 > The Component Library is available as both a managed and an unmanaged solution. Use the **managed** solution to [add components to your agents](#using-components-with-a-managed-solution) without modification. Use the **unmanaged** solution only if you need to [edit component internals](#customizing-components-with-an-unmanaged-solution). There is only one instance of each component per environment, so any edit you make to a topic, prompt, or flow inside the Component Library applies to **every agent** that uses that component in the same environment.
@@ -360,15 +360,15 @@ The Component Library is shipped as five separate solutions:
 
 Import the **Content Synthesizer** solution first — the Research and Executive Brief components depend on it. Only import the ServiceNow solution if you have a ServiceNow instance and need incident management capabilities.
 
-There are two ways to install components: using the built-in Component Library in the Copilot Studio Kit, or by manually importing solutions.
+There are two ways to install components: using the built-in Component Library in the Copilot Agent Kit, or by manually importing solutions.
 
-#### Option A — Install from the Copilot Studio Kit (recommended)
+#### Option A — Install from the Copilot Agent Kit (recommended)
 
-If you are running the Copilot Studio Kit, you can browse and install components directly from the built-in **Component Library** page.
+If you are running the Copilot Agent Kit, you can browse and install components directly from the built-in **Component Library** page.
 
-![Component Library in the Copilot Studio Kit](docs/images/component-library.png)
+![Component Library in the Copilot Agent Kit](docs/images/component-library.png)
 
-1.  In the Copilot Studio Kit, select **Component Library** in the left navigation under Productivity.
+1.  In the Copilot Agent Kit, select **Component Library** in the left navigation under Productivity.
 2.  Browse the available components or use the category tabs and search bar to find what you need.
 3.  Select a component card to open the component details dialog.
 
@@ -384,13 +384,13 @@ The details dialog shows the component description, category, input/output varia
 
 #### Option B — Manual import via Power Apps
 
-Use this option if you do not have the Copilot Studio Kit installed, or if you downloaded the solutions .zip from the Component Library and need to import them manually.
+Use this option if you do not have the Copilot Agent Kit installed, or if you downloaded the solutions .zip from the Component Library and need to import them manually.
 
 ##### Step 1 — Download and extract the solutions
 
 All five component solutions are distributed as a single compressed (.zip) file. You can get this file in one of two ways:
 
-*   **From the Copilot Studio Kit** — select the **Download** button on any component in the Component Library.
+*   **From the Copilot Agent Kit** — select the **Download** button on any component in the Component Library.
 *   **From GitHub** — go to the [latest release](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/releases/latest) and download the component solutions .zip under Assets.
 
 After downloading:
@@ -549,8 +549,8 @@ Common customizations include:
 
 ## Related content
 
-*   [Copilot Studio Kit overview](https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-overview)
-*   [Install Copilot Studio Kit](https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-install)
+*   [Copilot Agent Kit overview](https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-overview)
+*   [Install Copilot Agent Kit](https://learn.microsoft.com/microsoft-copilot-studio/guidance/kit-install)
 *   [Create and share reusable component collections](https://learn.microsoft.com/microsoft-copilot-studio/authoring-export-import-copilot-components)
 *   [Create and manage solutions in Copilot Studio](https://learn.microsoft.com/microsoft-copilot-studio/authoring-solutions-overview)
 *   [Export and import agents using solutions](https://learn.microsoft.com/microsoft-copilot-studio/authoring-solutions-import-export)
@@ -558,6 +558,6 @@ Common customizations include:
 *   [Add an agent flow to an agent as a tool](https://learn.microsoft.com/microsoft-copilot-studio/flow-agent)
 *   [Use Power Platform connectors as tools](https://learn.microsoft.com/microsoft-copilot-studio/advanced-connectors)
 *   [Use prompts to make your agent perform specific tasks](https://learn.microsoft.com/microsoft-copilot-studio/nlu-prompt-node)
-*   [Copilot Studio Kit on GitHub](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit)
+*   [Copilot Agent Kit on GitHub](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit)
 *   [Microsoft Copilot Studio documentation](https://learn.microsoft.com/microsoft-copilot-studio/)
 *   [AI Builder documentation](https://learn.microsoft.com/ai-builder/)

--- a/CONFIGURE_COPILOTS.md
+++ b/CONFIGURE_COPILOTS.md
@@ -1,6 +1,6 @@
-# Configure agents in Power CAT Copilot Studio Kit
+# Configure agents in Copilot Agent Kit
 
-The custom agents you create and configure in Microsoft Copilot Studio can be tested from the Power CAT Copilot Studio Kit.
+The custom agents you create and configure in Microsoft Copilot Studio can be tested from the Copilot Agent Kit.
 To do this, you need to create a **Agent Configuration** record that will contain the required information to connect to these agents and run tests against them.
 
 ![configure agents](https://github.com/user-attachments/assets/23586e64-4ea2-4056-abbc-17bb3d4e69a5)
@@ -14,7 +14,7 @@ Multiple configuration types are supported in single agent configuration record.
 
 ## Create new Agent Configuration record
 
-1. Open the Power CAT Copilot Studio Kit application (as seen in [installation instructions](./INSTALLATION_INSTRUCTIONS.md#access-the-copilot-studio-accelerator-app)).
+1. Open the Copilot Agent Kit application (as seen in [installation instructions](./INSTALLATION_INSTRUCTIONS.md#access-the-copilot-studio-accelerator-app)).
 2. Navigate to **Agents**.
 3. Create a **New** Agent Configuration record.
 4. Fill in the following  **information**.
@@ -108,11 +108,11 @@ Note: These fields are mandatory for all configuration types.
 
 ## Note about end user authentication
 
-Copilot Studio Kit supports testing custom agents with Entra ID v2 (Azure Active Directory v2) service provider (with SSO) for end user authentication. To enable Copilot Studio Kit end user authentication on your application, please see instructions [here](./ENABLE-AUTHENTICATION.md).
+Copilot Agent Kit supports testing custom agents with Entra ID v2 (Azure Active Directory v2) service provider (with SSO) for end user authentication. To enable Copilot Agent Kit end user authentication on your application, please see instructions [here](./ENABLE-AUTHENTICATION.md).
 
 ## Note about results enrichment with Dataverse Conversation Transcripts
 
-* For the Copilot Studio Kit to be able to retrieve Conversation Transcript records from other Power Platform environments, the Microsoft Dataverse connection that is used when setting up solution must have `Read` access on the `ConversationTranscript` table records in the target environments.
+* For the Copilot Agent Kit to be able to retrieve Conversation Transcript records from other Power Platform environments, the Microsoft Dataverse connection that is used when setting up solution must have `Read` access on the `ConversationTranscript` table records in the target environments.
 * Only environments within the same tenant can be targeted.
 
 ## Note about results enrichment with Application Insights
@@ -120,7 +120,7 @@ Copilot Studio Kit supports testing custom agents with Entra ID v2 (Azure Active
 * For enriching test results from Application Insights, app registration is required within the same tenant as the Application Insights resource
 * Application Insights resource and the application can reside in a different tenant than the custom agent being tested
 * For detailed instructions on how to register the application and get the required information for the Application Insights resource, please see [here](./ENABLE-APPINSIGHTS.md).
-* Make sure that the custom agent is configured to send telemetry to Application Insights resource and that it is the same as in the agent configuration in the Copilot Studio Kit. For information on how to connect your custom Agent to Application Insights, please see [here](./ENABLE-APPINSIGHTS.md)
+* Make sure that the custom agent is configured to send telemetry to Application Insights resource and that it is the same as in the agent configuration in the Copilot Agent Kit. For information on how to connect your custom Agent to Application Insights, please see [here](./ENABLE-APPINSIGHTS.md)
 
 ## Configure secrets in Azure Key Vault
 
@@ -128,15 +128,15 @@ Copilot Studio Kit supports testing custom agents with Entra ID v2 (Azure Active
 > Configuring this requires at least the System Administrator security role on the environment, as well as specific permissions in the Azure Key Vault.
 
 If you do not want to store secrets directly in Dataverse, you can choose to store them in Azure Key Vault.
-If you choose to do so, you then need to use environment variables of type secrets so that the Power CAT Copilot Studio Kit can fetch secrets from the key vault when running tests.
+If you choose to do so, you then need to use environment variables of type secrets so that the Copilot Agent Kit can fetch secrets from the key vault when running tests.
 Because each agent configuration may target a different agent and use a different secret, you need to create individual environment variables for each secret.
 
 1. Configure your Azure Key Vault by following this documentation: [Configure Azure Key Vault](https://learn.microsoft.com/power-apps/maker/data-platform/environmentvariables-azure-key-vault-secrets#configure-azure-key-vault).
 2. Go to **[make.powerapps.com](https://make.powerapps.com/)**
-3. Select the **environment** in which you want to install the Power CAT Copilot Studio Kit.
+3. Select the **environment** in which you want to install the Copilot Agent Kit.
 4. Go to **Solutions**
 5. Select **Common Data Services Default Solution** <br>
-   _Note: you can choose to create or use your own custom solution as well. The idea here is to create environment variables that will be used by Power CAT Copilot Studio Kit to retrieve secrets from the Azure Key Vault._
+   _Note: you can choose to create or use your own custom solution as well. The idea here is to create environment variables that will be used by Copilot Agent Kit to retrieve secrets from the Azure Key Vault._
 6. Follow the steps in: [Create a new environment variable for the Key Vault secret](https://learn.microsoft.com/power-apps/maker/data-platform/environmentvariables-azure-key-vault-secrets#create-a-new-environment-variable-for-the-key-vault-secret)
 7. Once created, use the environment variable **schema name** (e.g., cr42e_Copilot1DirectLineSecret) in the agent Configuration record.
 

--- a/CONFIGURE_TESTS.md
+++ b/CONFIGURE_TESTS.md
@@ -1,10 +1,10 @@
-# Configure tests in Power CAT Copilot Studio Kit
+# Configure tests in Copilot Agent Kit
 
 ## Create a new test set
 
 **Test sets** are used to group multiple **tests** together. That way, when running tests, you select a test set, and each test in the test set will be executed as part of the run.
 
-1. Open the Power CAT Copilot Studio Kit application (as seen in [installation instructions](./INSTALLATION_INSTRUCTIONS.md#access-the-copilot-studio-accelerator-app))
+1. Open the Copilot Agent Kit application (as seen in [installation instructions](./INSTALLATION_INSTRUCTIONS.md#access-the-copilot-studio-accelerator-app))
 2. Navigate to **Test Sets**.
 3. Create a **New** Agent Test Set record.
 4. Provide a **Name**.

--- a/CONVERSATION_KPI.md
+++ b/CONVERSATION_KPI.md
@@ -4,11 +4,11 @@ Conversation KPI are designed to help makers track and analyze the performance o
 
 * Aggregated Data: The feature surfaces simplified conversation outcome results, making it easier to understand the performance of your custom agents. This includes metrics such as the number of sessions, turns, and the global outcome of conversations (e.g., resolved, partially resolved, escalated, or abandoned).
 
-* Sample Power BI Reports: The Copilot Studio Kit offers a sample Power BI reports based on aggregated KPIs. These reports provide a visual representation of the data, helping you quickly identify trends and areas for improvement, and provide a solid starting point for your own custom reports.
+* Sample Power BI Reports: The Copilot Agent Kit offers a sample Power BI reports based on aggregated KPIs. These reports provide a visual representation of the data, helping you quickly identify trends and areas for improvement, and provide a solid starting point for your own custom reports.
 
 * Tracked Variables: You can define specific variables to track as part of the aggregated conversation KPI, such as custom Net Promoter Score (NPS) or other relevant metrics. This allows you to tailor the KPIs to your specific needs.
 
-* Optional Full Transcript Storage: Users have the option to include the full conversation transcript with the KPI records (as file). This allows for a more detailed analysis if needed, using the transcript visualizer built into the Copilot Studio Kit.
+* Optional Full Transcript Storage: Users have the option to include the full conversation transcript with the KPI records (as file). This allows for a more detailed analysis if needed, using the transcript visualizer built into the Copilot Agent Kit.
 
 * Long-term tracking: Conversation KPI can be stored in the system for as long as required which allows tracking the impact of improvements and performance of custom copilots over long time-period.
 

--- a/ENABLE-APPINSIGHTS.md
+++ b/ENABLE-APPINSIGHTS.md
@@ -4,12 +4,12 @@
 
 - Application Insights resource has been created and Agent has been configured to send telemetry to it. Please see instructions [here](https://learn.microsoft.com/microsoft-copilot-studio/advanced-bot-framework-composer-capture-telemetry?tabs=webApp#connect-your-copilot-studio-copilot-to-application-insights).
 
-## Steps to enable Application Insights support in Copilot Studio Kit
+## Steps to enable Application Insights support in Copilot Agent Kit
 
-To enable Application Insights support in Copilot Studio Kit, new application registration is required.
+To enable Application Insights support in Copilot Agent Kit, new application registration is required.
 
 > [!NOTE]  
-> If you have already created app registration for Copilot Studio Kit to use with user authentication, you **may** reuse that application for App Insights enrichment instead of creating another application. If you wish to do that, you can skip step 1 below and start with step 2 after navigating to the existing app registration. 
+> If you have already created app registration for Copilot Agent Kit to use with user authentication, you **may** reuse that application for App Insights enrichment instead of creating another application. If you wish to do that, you can skip step 1 below and start with step 2 after navigating to the existing app registration. 
 
 1. [Register new application in Microsoft Entra ID](https://learn.microsoft.com/azure/azure-monitor/logs/api/register-app-for-token) and add new client secret for it. Make note of the secret as it will be used later as **App Insights Secret** in the Agent configuration (depending on App Insights Secret location, please see the details [here](./CONFIGURE_COPILOTS.md#configure-a-new-copilot).)
 1. Make note of the **Directory (tenant) ID** and **Application (client) ID** of the application as they will be used later as **App Insights Tenant ID** and **App Insights Client ID** in the Agent configuration

--- a/ENABLE-AUTHENTICATION.md
+++ b/ENABLE-AUTHENTICATION.md
@@ -1,11 +1,11 @@
 # Enable user authentication
 
-**Copilot Studio Kit** supports testing custom Agents with user authentication using Entra ID v2 (Azure Active Directory v2) as the service provider with SSO enabled. These instructions include all the steps required to enable end user authentication on your agent in Copilot Studio, create and configure the required applications in Azure Portal and finally create the agent configuration in Copilot Studio Kit.
+**Copilot Agent Kit** supports testing custom Agents with user authentication using Entra ID v2 (Azure Active Directory v2) as the service provider with SSO enabled. These instructions include all the steps required to enable end user authentication on your agent in Copilot Studio, create and configure the required applications in Azure Portal and finally create the agent configuration in Copilot Agent Kit.
 
 ## Prerequisites
-- Copilot Studio Kit has been installed
+- Copilot Agent Kit has been installed
 
-## Create authentication application for Copilot Studio Kit
+## Create authentication application for Copilot Agent Kit
 Related instructions in Microsoft Learn: https://learn.microsoft.com/en-us/microsoft-copilot-studio/configure-sso?tabs=classic#create-an-app-registration-in-microsoft-entra-id-for-your-custom-canvas
 
 1. Navigate to **Azure Portal**
@@ -15,7 +15,7 @@ Related instructions in Microsoft Learn: https://learn.microsoft.com/en-us/micro
 1. Under **Supported account types**, select **Accounts in any organizational tenant (Any Microsoft Entra ID directory - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)**.
 1. Leave the **Redirect URI** section blank for now. We will be entering that information later in the next steps.
 1. Select **Register**, you will be sent to the "**Overview**"-page of your new application.
-1. Make note of the "**Directory (tenant) ID**" and "**Application (client) ID**". We will need these when creating agent registration in Copilot Studio Kit and associating the Copilot Studio with the Copilot Studio Kit app.
+1. Make note of the "**Directory (tenant) ID**" and "**Application (client) ID**". We will need these when creating agent registration in Copilot Agent Kit and associating the Copilot Studio with the Copilot Agent Kit app.
 1. Expand **Manage** and select **Authentication**
 1. Under **Platform configurations**, select **Add a platform**, and then select **Web**.
 1. Under **Redirect URIs**, enter your **Dataverse environment URL** (https://\<hostname>\.crm.dynamics.com/)
@@ -90,9 +90,9 @@ Related instructions in Microsoft Learn: https://learn.microsoft.com/microsoft-c
 1. Click **Publish**, then **Publish** again from the dialog.
 
 ## Create agent configuration with end user authentication enabled
-Related instructions in the Copilot Studio Kit repository: https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/main/CONFIGURE_COPILOTS.md
+Related instructions in the Copilot Agent Kit repository: https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/main/CONFIGURE_COPILOTS.md
 
-1. Navigate to Copilot Studio Kit
+1. Navigate to Copilot Agent Kit
 1. Select **Agents** from the navigation.
 1. Click **New**
 1. Enter **Name**
@@ -107,8 +107,8 @@ Related instructions in the Copilot Studio Kit repository: https://github.com/mi
 Now you are ready to start testing your agent with end user authentication enabled!
 
 To recap what we did here:
-- Created app registration specifically for Copilot Studio Kit authentication purpose
+- Created app registration specifically for Copilot Agent Kit authentication purpose
 - Created app registration for Copilot Studio authentication
-- Linked the applications so that Copilot Studio Kit is able to authenticate to Direct Line via Copilot Studio authentication application
+- Linked the applications so that Copilot Agent Kit is able to authenticate to Direct Line via Copilot Studio authentication application
 - Enabled authentication in custom agent in Copilot Studio
-- Created agent configuration in Copilot Studio Kit with end user authentication enabled
+- Created agent configuration in Copilot Agent Kit with end user authentication enabled

--- a/INSTALLATION_INSTRUCTIONS.md
+++ b/INSTALLATION_INSTRUCTIONS.md
@@ -1,20 +1,20 @@
 Before you begin, please make sure to study the [prerequisites](/PREREQUISITES.md)
 
 > [!NOTE]
-> Before you download and install the Copilot Studio Kit, ensure that you enable [code components](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/component-framework-for-canvas-apps#enable-the-power-apps-component-framework-feature) and [code apps](https://learn.microsoft.com/en-us/power-apps/developer/code-apps/overview#enable-code-apps-on-a-power-platform-environment) in your environment first.
+> Before you download and install the Copilot Agent Kit, ensure that you enable [code components](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/component-framework-for-canvas-apps#enable-the-power-apps-component-framework-feature) and [code apps](https://learn.microsoft.com/en-us/power-apps/developer/code-apps/overview#enable-code-apps-on-a-power-platform-environment) in your environment first.
 
 > [!NOTE]
-> May 2025 release onwards the Copilot Studio Kit has had a **setup wizard**, which allows viewing and editing connection references, environment variables and set up cloud flows. Please see more information from [here](./SETUP_WIZARD.md).
+> May 2025 release onwards the Copilot Agent Kit has had a **setup wizard**, which allows viewing and editing connection references, environment variables and set up cloud flows. Please see more information from [here](./SETUP_WIZARD.md).
 
-# Installing the Power Cat Copilot Studio Kit ([Appsource](http://aka.ms/DownloadCopilotStudioKit))
+# Installing the Copilot Agent Kit ([Appsource](http://aka.ms/DownloadCopilotStudioKit))
 
 ## Deploy from AppSource
 
-1. Navigate to Copilot Studio Kit in [AppSource](http://aka.ms/DownloadCopilotStudioKit)
+1. Navigate to Copilot Agent Kit in [AppSource](http://aka.ms/DownloadCopilotStudioKit)
 1. Click **Get it now**
 1. Sign-in if required
-1. You are presented with **Install Copilot Studio Kit** view
-1. From the drop-down list, select the environment where you want to deploy Copilot Studio Kit
+1. You are presented with **Install Copilot Agent Kit** view
+1. From the drop-down list, select the environment where you want to deploy Copilot Agent Kit
 1. Carefully study the presented Terms and Statements, if you agree, check the boxes to indicate that and click **Install**
 1. Installation will begin
 
@@ -26,23 +26,23 @@ After the installation finishes, proceed with these post deployment steps:
 1. Go to **Solutions**
 1. Select **Default Solution**
 1. Select **Connection references**
-1. Locate "**Copilot Studio Kit - Dataverse**" and open it for editing.
+1. Locate "**Copilot Agent Kit - Dataverse**" and open it for editing.
 1. Ensure all required fields are filled and the selected connection is valid. Create new connection to Dataverse as required.
 1. Click **Save**
 
 Please see the common and optional configuration steps below.
 
-# Installing the Power CAT Copilot Studio Kit (Github)
+# Installing the Copilot Agent Kit (Github)
 
 ## Download
 
-1. Download the latest version of the Power CAT Copilot Studio Kit **managed** solution by going to the latest GitHub Release below: <br>
-   [Power Cat Copilot Studio Kit Latest GitHub Releases](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/releases/latest) 
+1. Download the latest version of the Copilot Agent Kit **managed** solution by going to the latest GitHub Release below: <br>
+   [Copilot Agent Kit Latest GitHub Releases](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/releases/latest) 
 
 ## Install CopilotStudioKit.zip
 
 1. Go to **[make.powerapps.com](https://make.powerapps.com/)**
-1. Select to the **environment** in which you want to install the Power CAT Copilot Studio Kit.
+1. Select to the **environment** in which you want to install the Copilot Agent Kit.
 1. Go to **Solutions**
 1. Select **Import Solution**
 1. Select **Browse**
@@ -55,10 +55,10 @@ Please see the common and optional configuration steps below.
 
 ## Upgrading existing solution
 
-If you have earlier version of Copilot Studio Kit installed and want to upgrade it to the latest version, follow these steps:
+If you have earlier version of Copilot Agent Kit installed and want to upgrade it to the latest version, follow these steps:
 
 1. Go to **[make.powerapps.com](https://make.powerapps.com/)**
-1. Select to the **environment** in which you want to install the Power CAT Copilot Studio Kit.
+1. Select to the **environment** in which you want to install the Copilot Agent Kit.
 1. Go to **Solutions**
 1. Select **Import Solution**
 1. Select **Browse**
@@ -70,7 +70,7 @@ If you have earlier version of Copilot Studio Kit installed and want to upgrade 
 1. Select **Import**
 
 > [!NOTE]  
-> While upgrading the Copilot Studio Kit, you might encounter the following error: "*Solution "Power CAT Copilot Studio Kit" failed to import: ImportAsHolding failed with exception: Cannot delete attribute: cat_copilottestrunid from Entity: cat_CopilotTestRun since the attribute is not a custom field.*".
+> While upgrading the Copilot Agent Kit, you might encounter the following error: "*Solution "Copilot Agent Kit" failed to import: ImportAsHolding failed with exception: Cannot delete attribute: cat_copilottestrunid from Entity: cat_CopilotTestRun since the attribute is not a custom field.*".
 >
 > This is a known issue that is being investigated. As a workaround, stage the upgrade before applying it. For detailed instructions, please see [here](https://learn.microsoft.com/power-apps/maker/data-platform/update-solutions).
 
@@ -85,24 +85,24 @@ Please note that the connection to the SharePoint should point to the source Sha
 1. Go to **Solutions**
 1. Select **Default Solution**
 1. Select **Connection references**
-1. Locate "**Copilot Studio Kit - SharePoint**" and open it for editing.
+1. Locate "**Copilot Agent Kit - SharePoint**" and open it for editing.
 1. Ensure all required fields are filled and the selected connection is valid. Create new connection to SharePoint as required.
 1. Click **Save**
 
 ## Configure Agent Inventory
 Following steps are **optional** and required only if you plan to use the **Agent Inventory** feature. You can also set these later at any time before using the feature.
 
-Please note that the visibility to the agents is limited and controlled by the connection references in the solution. **Copilot Studio Kit - Power Platform for Admins** is used to fetch the list of environments in the tenant and **Copilot Studio Kit - Dataverse** is used to gather the agent information from the environments. For full visibility, the connection references have to be configured with account having Power Platform admin role and system admin level permission to all the environments. Other accounts can be used as well, but the visibility of the agent inventory is limited to the environments the user has system admin access to.
+Please note that the visibility to the agents is limited and controlled by the connection references in the solution. **Copilot Agent Kit - Power Platform for Admins** is used to fetch the list of environments in the tenant and **Copilot Agent Kit - Dataverse** is used to gather the agent information from the environments. For full visibility, the connection references have to be configured with account having Power Platform admin role and system admin level permission to all the environments. Other accounts can be used as well, but the visibility of the agent inventory is limited to the environments the user has system admin access to.
 
 1. Go to **[make.powerapps.com](https://make.powerapps.com/)**
 1. Go to **Solutions**
 1. Select **Default Solution**
 1. Select **Connection references**
-1. Locate "**Copilot Studio Kit - Power Platform for Admins**" and open it for editing.
+1. Locate "**Copilot Agent Kit - Power Platform for Admins**" and open it for editing.
 1. This connection is used to list all the environments in the tenant. Use account with Power Platform Admin level permissions to get full visibility.
 1. Ensure all required fields are filled and the selected connection is valid.
 1. Click **Save**
-1. Locate "**Copilot Studio Kit - Dataverse**" and open it for editing.
+1. Locate "**Copilot Agent Kit - Dataverse**" and open it for editing.
 1. This connection is used to gather all the agent details from the environments. Use account with System Admin level permissions to all environments to get full visibility. Please note that this connection is used with other features in the Kit as well.
 1. Ensure all required fields are filled and the selected connection is valid.
 1. Click **Save**
@@ -113,9 +113,9 @@ Please note that the visibility to the agents is limited and controlled by the c
 > If you have not set up the environment variable for **SharePoint Synchronization** in the previous step, you don't have to enable the related flows (they start with **Sharepoint Synchronization**). This does not impact other features in the Kit.
 
 1. Navigate to **Power Automate**
-1. Make sure the environment with the Copilot Studio Kit is selected
+1. Make sure the environment with the Copilot Agent Kit is selected
 1. Select **Solutions**
-1. Select **Copilot Studio Kit**
+1. Select **Copilot Agent Kit**
 1. Select **Cloud flows**
 1. Make sure all the flows are enabled (Status = On)
 1. Enable any flows that are not enabled, in the following order
@@ -125,7 +125,7 @@ Please note that the visibility to the agents is limited and controlled by the c
 
 ## Configure the embedded Conversation KPI dashboard
 
-These steps are required only if you plan to use the embedded Conversation KPI dashboard in the Copilot Studio Kit.
+These steps are required only if you plan to use the embedded Conversation KPI dashboard in the Copilot Agent Kit.
 
 During the steps, please make note of the following values:
 - Workspace name
@@ -153,27 +153,27 @@ During the steps, please make note of the following values:
 
 In order to set up the embedded Conversation KPIs dashboard, you need to update the related environment variable with correct identifiers.
 
-1. Navigate to Power Apps and to the environment where you installed the Copilot Studio Kit
+1. Navigate to Power Apps and to the environment where you installed the Copilot Agent Kit
 1. Open **Solutions** and **Default Solution**
 1. Select **Environment variables**
 1. Locate and select **Conversation KPIs Report**
 1. Replace placeholders in the **Default Value** with the actual **Workspace name**, **Workspace GUID**, **Report Name** and **Report GUID** you noted down during the publishing process.
 1. Save
 
-## Access the Power CAT Copilot Studio Kit app
+## Access the Copilot Agent Kit app
 
 1. Go to **[make.powerapps.com](https://make.powerapps.com/)**
-1. Select to the **environment** in which you want to install the Power CAT Copilot Studio Kit.
+1. Select to the **environment** in which you want to install the Copilot Agent Kit.
 1. Navigate to **Apps**.
-1. Locate and select **Power CAT Copilot Studio Kit**.
+1. Locate and select **Copilot Agent Kit**.
 1. Select **Play**.
 1. **Bookmark** the app (optional)
 
-### Share the Copilot Studio Kit app                                                                                                                                                                                         
+### Share the Copilot Agent Kit app                                                                                                                                                                                         
 After verifying the app launches successfully, the owner (or System Administrator who installed the kit) should share it with other users on the team:                                                                       
 1. Go to [make.powerapps.com](https://make.powerapps.com/)                                                                                                                                                                
 2. Click **Apps** in the left navigation
-3. Search for **Copilot Studio Kit** and locate the one with type **Code** (not the Model-driven app)
+3. Search for **Copilot Agent Kit** and locate the one with type **Code** (not the Model-driven app)
 4. Click the **three dots (...)** menu next to the app
 5. Select **Share**
 6. Search for and add the users or security groups who need access

--- a/MICROSOFTAUTHENTICATION.md
+++ b/MICROSOFTAUTHENTICATION.md
@@ -97,7 +97,7 @@ Based on the [Microsoft Agents Sample Documentation](https://github.com/microsof
 2. **Create New Registration**
 
    - Click **New registration**
-   - Provide a **Name**: `Copilot Studio Kit - Microsoft Auth (Name can be anything)`
+   - Provide a **Name**: `Copilot Agent Kit - Microsoft Auth (Name can be anything)`
    - Choose **Accounts in this organizational directory only**
    - For **Redirect URI**: **Leave blank** (we'll configure this after creation)
    - Click **Register**

--- a/OFFICEHOURS.md
+++ b/OFFICEHOURS.md
@@ -1,13 +1,13 @@
-# Copilot Studio Kit Office Hours
-## Join the Copilot Studio Kit Office hours
+# Copilot Agent Kit Office Hours
+## Join the Copilot Agent Kit Office hours
 
 > [!NOTE]
-> Starting May 13, 2026, Copilot Studio Kit Office Hours will move to an every-other-week schedule.
+> Starting May 13, 2026, Copilot Agent Kit Office Hours will move to an every-other-week schedule.
 > The format is also changing: each session will now include updates and demos from the team, including highlights of new features and walkthroughs showing how to configure features or accomplish more complex scenarios with existing capabilities.
 > * US-friendly slot: 10:05 AM Pacific Time (PT)
 > * APAC-friendly slot: 9:05 PM Pacific Time (PT) (next-day morning in IST)
 
-During office hours we will have Copilot Studio Kit team present and part of the meeting is dedicated for updates from the team, and demonstration of new features.
+During office hours we will have Copilot Agent Kit team present and part of the meeting is dedicated for updates from the team, and demonstration of new features.
 
 There are two regional time slots, and you may join either (or both) depending on your preferred time zone.
 
@@ -29,7 +29,7 @@ This session is open to public, will be attended by multiple customers and partn
 Please state any questions with the appropriate level of detail for this broader audience.
 We are unable to do detailed troubleshooting or consulting not relevant to a broader audience in this session.
 
-Remember: You can always raise an issue to the Copilot Studio Kit team in the Github: https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/issues
+Remember: You can always raise an issue to the Copilot Agent Kit team in the Github: https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/issues
 
 | Session (US Date / APAC Date) | Status | Regional Slot | Notes |
 |-------------------------------|--------|----------------|--------|

--- a/POWER_SHIELD.md
+++ b/POWER_SHIELD.md
@@ -16,9 +16,9 @@ Power Shield enables organizations to manage Power Platform connector access thr
 
 Power Shield is delivered as an embedded feature within two dedicated code apps and is also accessible from the model-driven app:
 
-- **Copilot Studio Kit** (model-driven app) — launches Power Shield and routes to the appropriate code app based on the user's security role
-- **Copilot Studio Kit for Makers** — submit and manage connector access requests
-- **Copilot Studio Kit for Admins** — review, approve, and configure Power Shield
+- **Copilot Agent Kit** (model-driven app) — launches Power Shield and routes to the appropriate code app based on the user's security role
+- **Copilot Agent Kit for Makers** — submit and manage connector access requests
+- **Copilot Agent Kit for Admins** — review, approve, and configure Power Shield
 
 ## Key concepts
 
@@ -35,10 +35,10 @@ Power Shield is delivered as an embedded feature within two dedicated code apps 
 
 Before using Power Shield, ensure you have:
 
-- **Copilot Studio Kit prerequisites**: All [prerequisites for the Copilot Studio Kit](PREREQUISITES.md) installed and configured for both code apps.
+- **Copilot Agent Kit prerequisites**: All [prerequisites for the Copilot Agent Kit](PREREQUISITES.md) installed and configured for both code apps.
 - **Security roles**: Users must be assigned one of the following Dataverse security roles:
-  - **CSK - Maker** or **System Administrator** — maker experience in Copilot Studio Kit for Makers
-  - **CSK - Administrator** or **System Administrator** — admin experience in Copilot Studio Kit for Admins
+  - **CAK - Maker** or **System Administrator** — maker experience in Copilot Agent Kit for Makers
+  - **CAK - Administrator** or **System Administrator** — admin experience in Copilot Agent Kit for Admins
 - **Power Platform Administrator role** (admins only): Admins who approve requests and create DLP policies must also have the **Power Platform Administrator** role assigned in the [Microsoft 365 admin center](https://admin.microsoft.com). This Microsoft Entra ID role grants permission to create, update, and delete DLP policies via the Power Platform for Admins connector. Without it, DLP policy creation fails after approval.
 
 > [!WARNING]
@@ -138,7 +138,7 @@ The flow runs on a **daily schedule**. The connector sync preserves admin overri
 
 ### Maker
 
-Requires the **CSK - Maker** or **System Administrator** security role. Access Power Shield through the **Copilot Studio Kit for Makers** app (a **[Maker]** badge displays in the header).
+Requires the **CAK - Maker** or **System Administrator** security role. Access Power Shield through the **Copilot Agent Kit for Makers** app (a **[Maker]** badge displays in the header).
 
 Makers can:
 
@@ -151,7 +151,7 @@ Makers can:
 
 ### Admin
 
-Requires the **CSK - Administrator** or **System Administrator** security role. Access Power Shield through the **Copilot Studio Kit for Admins** app (an **[Admin]** badge displays in the header). Approving requests also requires the **Power Platform Administrator** role (see [Prerequisites](#prerequisites)) — the Dataverse security role controls app access; the Power Platform Administrator role controls DLP policy operations.
+Requires the **CAK - Administrator** or **System Administrator** security role. Access Power Shield through the **Copilot Agent Kit for Admins** app (an **[Admin]** badge displays in the header). Approving requests also requires the **Power Platform Administrator** role (see [Prerequisites](#prerequisites)) — the Dataverse security role controls app access; the Power Platform Administrator role controls DLP policy operations.
 
 Admins can:
 
@@ -168,28 +168,28 @@ Users with the **System Administrator** role have access to both apps.
 
 ### Launch options
 
-Power Shield is accessible from three apps within the Copilot Studio Kit solution. Choose the launch option that matches your role and workflow.
+Power Shield is accessible from three apps within the Copilot Agent Kit solution. Choose the launch option that matches your role and workflow.
 
 | App | Type | Audience | Internal name |
 |-----|------|----------|---------------|
-| Copilot Studio Kit | Model-Driven App | All users (auto-routes by role) | `cat_CopilotStudioAccelerator` |
-| Copilot Studio Kit for Admins | Code App | Admins | `cat_copilotstudiokitforadmins` |
-| Copilot Studio Kit for Makers | Code App | Makers | `cat_copilotstudiokitformakers` |
+| Copilot Agent Kit | Model-Driven App | All users (auto-routes by role) | `cat_CopilotStudioAccelerator` |
+| Copilot Agent Kit for Admins | Code App | Admins | `cat_copilotstudiokitforadmins` |
+| Copilot Agent Kit for Makers | Code App | Makers | `cat_copilotstudiokitformakers` |
 
-#### Option A: Launch from the Copilot Studio Kit model-driven app
+#### Option A: Launch from the Copilot Agent Kit model-driven app
 
-1. Open the **Copilot Studio Kit** model-driven app.
+1. Open the **Copilot Agent Kit** model-driven app.
 2. In the left navigation, expand the **Governance** area.
 3. Select **Power Shield**. The unified launcher detects your security role and routes you to the appropriate code app (admin app takes precedence if you have both roles).
 
-#### Option B: Launch from Copilot Studio Kit for Admins
+#### Option B: Launch from Copilot Agent Kit for Admins
 
-1. Open the **Copilot Studio Kit for Admins** code app.
+1. Open the **Copilot Agent Kit for Admins** code app.
 2. In the left sidebar, navigate to **Governance** → **Power Shield**.
 
-#### Option C: Launch from Copilot Studio Kit for Makers
+#### Option C: Launch from Copilot Agent Kit for Makers
 
-1. Open the **Copilot Studio Kit for Makers** code app.
+1. Open the **Copilot Agent Kit for Makers** code app.
 2. In the left sidebar, navigate to **Governance** → **Power Shield**.
 
 ## Maker workflow
@@ -413,7 +413,7 @@ Four configuration areas:
 
 ### Connection Health
 
-Connection Health is the single place to manage Power Shield connection references and cloud flow activation. Use it for initial setup and ongoing monitoring — connections can break and flows can be turned off at any time. Available only to users with the **CSK - Administrator** or **System Administrator** security role.
+Connection Health is the single place to manage Power Shield connection references and cloud flow activation. Use it for initial setup and ongoing monitoring — connections can break and flows can be turned off at any time. Available only to users with the **CAK - Administrator** or **System Administrator** security role.
 
 Open Connection Health from either:
 
@@ -694,7 +694,7 @@ All tables use the `cat_` publisher prefix.
 
 **Cannot see the Settings Hub or admin configuration screens**
 
-- Requires the **CSK - Administrator** security role. Contact your Dataverse administrator.
+- Requires the **CAK - Administrator** security role. Contact your Dataverse administrator.
 
 **Connector icons not loading**
 

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,17 +1,17 @@
-# Power CAT Copilot Studio Kit prerequisites
+# Copilot Agent Kit prerequisites
 
-The Power CAT Copilot Studio Kit is built using Power Platform and requires adequate licensing and capacity.
+The Copilot Agent Kit is built using Power Platform and requires adequate licensing and capacity.
 
 ## Mandatory requirements
 
 - A [**Power Platform environment with Dataverse as a data store**](https://learn.microsoft.com/power-platform/admin/create-environment). <br>
-  Microsoft Dataverse is used to store the Power CAT Copilot Studio Kit configuration and test tables data. <br>
-  The user performing the installation of the Power CAT Copilot Studio Kit must have the **system administrator** security role on the environment.
+  Microsoft Dataverse is used to store the Copilot Agent Kit configuration and test tables data. <br>
+  The user performing the installation of the Copilot Agent Kit must have the **system administrator** security role on the environment.
 - Adequate licensing to run a **Power Apps model-driven application**.
 - Adequate licensing to run **Power Automate cloud flows** using **Premium** connectors.
 
 > [!NOTE]
-> Power CAT Copilot Studio Kit can be installed in the same environment where you host your custom agents, but this isn't mandatory. More information on licensing:
+> Copilot Agent Kit can be installed in the same environment where you host your custom agents, but this isn't mandatory. More information on licensing:
 > - If installed as part of Power Platform, refer to [Microsoft Power Platform Licensing Guide](https://go.microsoft.com/fwlink/?linkid=2085130).
 > - If installed as part of Dynamics 365, refer to  [Dynamics 365 Licensing Guide](https://go.microsoft.com/fwlink/p/?LinkId=866544)
 
@@ -20,7 +20,7 @@ The Power CAT Copilot Studio Kit is built using Power Platform and requires adeq
 * This solution requires PCF Components to be enabled for the Dataverse Environment before you install any of the solution files.  You can find details of how to turn that feature on in the public documentation page below,
   * [Enabling Power Apps Component Framework Feature](https://learn.microsoft.com/power-apps/developer/component-framework/component-framework-for-canvas-apps#enable-the-power-apps-component-framework-feature)
  
-* Copilot Studio Kit is using advanced components from the Creator Kit, please make sure to deploy it before deploying Copilot Studio Kit
+* Copilot Agent Kit is using advanced components from the Creator Kit, please make sure to deploy it before deploying Copilot Agent Kit
   * [Creator Kit installation instructions](https://learn.microsoft.com/power-platform/guidance/creator-kit/setup)
 
 * This solution requires Code Apps to be enabled on the environment.

--- a/PROMPT_ADVISOR.md
+++ b/PROMPT_ADVISOR.md
@@ -13,7 +13,7 @@ Users can enter a prompt and receive a confidence evaluation with detailed reaso
 
 ### Prerequisites
 
-1. A **Microsoft Dataverse Environment** with [AI Builder prompts enabled in the admin center](https://learn.microsoft.com/ai-builder/administer#enable-or-disable-ai-builder-preview-features) and Copilot Studio Kit
+1. A **Microsoft Dataverse Environment** with [AI Builder prompts enabled in the admin center](https://learn.microsoft.com/ai-builder/administer#enable-or-disable-ai-builder-preview-features) and Copilot Agent Kit
 1. **Permission requirements**: System customizer security role.
 1. **AI Builder credits**: Ensure [AI Builder credits](https://learn.microsoft.com/ai-builder/credit-management) are assigned to your environment.
 2. **Enable the Power Apps Component Framework Feature** : [Power Apps Component Framework Feature](https://learn.microsoft.com/power-apps/developer/component-framework/component-framework-for-canvas-apps#enable-the-power-apps-component-framework-feature)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Power CAT Copilot Studio Kit
+# Copilot Agent Kit
 
-The **Power CAT Copilot Studio Kit** is a comprehensive set of capabilities designed to augment [Microsoft Copilot Studio](https://aka.ms/CopilotStudio). The kit helps makers develop, govern, and test custom agents, use a large language model to validate AI-generated content, optimize prompts, and track aggregated key performance indicators of their custom agents.
+The **Copilot Agent Kit** is a comprehensive set of capabilities designed to augment [Microsoft Copilot Studio](https://aka.ms/CopilotStudio). The kit helps makers develop, govern, and test custom agents, use a large language model to validate AI-generated content, optimize prompts, and track aggregated key performance indicators of their custom agents.
 
 <img width="1879" height="1136" alt="new_landing_page" src="https://github.com/user-attachments/assets/e0dbbb47-d92b-489e-b517-a0b9cc336b81" />
 
 # Features
 ## Testing capabilities  
-Copilot Studio Kit allows makers to configure agents, tests and test sets, and use them to batch test their custom agents. Test runs produce detailed results including latencies, observed responses and run level aggregates. Different test types include response match, attachment match, topic match, multi-turn and generative answers which leverages AI Builder for response analysis. 
+Copilot Agent Kit allows makers to configure agents, tests and test sets, and use them to batch test their custom agents. Test runs produce detailed results including latencies, observed responses and run level aggregates. Different test types include response match, attachment match, topic match, multi-turn and generative answers which leverages AI Builder for response analysis. 
 
-***Copilot Studio Kit test automation now supports user-defined rubrics for generative answers.***
+***Copilot Agent Kit test automation now supports user-defined rubrics for generative answers.***
 
 More information on [testing capabilities](./TESTING_CAPABILITIES.md) 
 
@@ -26,12 +26,12 @@ More information on [Agent Insights Hub](https://github.com/microsoft/Power-CAT-
 
 ## Agent Debugger
 
-**Agent Debugger** is a diagnostic tool inside the **Copilot Studio Kit Admin** app that lets administrators load any recorded conversation and inspect every decision the agent made — step by step, with timing, token usage, knowledge sources, arguments, and observations — without leaving the Power Platform.
+**Agent Debugger** is a diagnostic tool inside the **Copilot Agent Kit Admin** app that lets administrators load any recorded conversation and inspect every decision the agent made — step by step, with timing, token usage, knowledge sources, arguments, and observations — without leaving the Power Platform.
 
 More information on [Agent Debugger](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/main/AGENT_DEBUGGER.md)
 
 ## Agent Library (Preview)
-The Agent Library is a centralized hub within the Copilot Studio Kit that helps makers discover, install, and manage pre-built agent templates and reusable components. Instead of building agents from scratch, you can browse a curated catalog of ready-to-use templates (Custom Agent and Declarative Agent) and components, install them directly into your environment, and customize them to fit your business needs.
+The Agent Library is a centralized hub within the Copilot Agent Kit that helps makers discover, install, and manage pre-built agent templates and reusable components. Instead of building agents from scratch, you can browse a curated catalog of ready-to-use templates (Custom Agent and Declarative Agent) and components, install them directly into your environment, and customize them to fit your business needs.
 
 More information on [Agent Library](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/main/AGENT_LIBRARY.md)
 
@@ -41,7 +41,7 @@ The Component Library is a collection of ready-to-use, pre-built components for 
 More information on [Component Library](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/blob/main/COMPONENT_LIBRARY.md)
 
 ## Rubrics refinement
-Rubrics Refinement is a powerful capability in Copilot Studio Kit that enables you to create, test, and iteratively improve reusable evaluation standards (rubrics) for AI-generated responses. This feature helps ensure that AI grading of your agent's responses aligns with human judgment and organizational quality standards.
+Rubrics Refinement is a powerful capability in Copilot Agent Kit that enables you to create, test, and iteratively improve reusable evaluation standards (rubrics) for AI-generated responses. This feature helps ensure that AI grading of your agent's responses aligns with human judgment and organizational quality standards.
 
 More information on [Rubrics Refinement](./RubricRefinement/01-rubrics-refinement-overview.md) 
 
@@ -100,13 +100,13 @@ More information on [Agent Value dashboard](./AGENT_VALUE_SUMMARY_DASHBOARD.md)
 
 ## Automated testing using Power Platform Pipelines (Advanced)
 
-This feature allows users to automate the testing and deployment of Copilot Studio custom agents using Power Platform Pipelines. The goal is to ensure that agents are automatically validated through test runs before they are deployed to target environments (production). By integrating Power Automate flows with Dataverse and the Copilot Studio Kit, this approach introduces a quality gate into the deployment process. Only agents that pass the required amount of test cases are allowed to proceed, ensuring higher reliability and reducing manual intervention. This method supports continuous delivery practices and enhances the overall governance of the deployment lifecycle.
+This feature allows users to automate the testing and deployment of Copilot Studio custom agents using Power Platform Pipelines. The goal is to ensure that agents are automatically validated through test runs before they are deployed to target environments (production). By integrating Power Automate flows with Dataverse and the Copilot Agent Kit, this approach introduces a quality gate into the deployment process. Only agents that pass the required amount of test cases are allowed to proceed, ensuring higher reliability and reducing manual intervention. This method supports continuous delivery practices and enhances the overall governance of the deployment lifecycle.
 
 More information on [automated testing using Power Platform Pipelines](./AUTOMATED_TESTING.md)
 
 # Setup instructions and documentation
 
-There is a Setup Wizard in the Kit which allows easy editing of connection references and environment variables as well as turning on cloud flows. After deploying the Kit from either AppSource or GitHub, you may access the Setup Wizard from the Home-page of the Copilot Studio Kit. Please see additional information [here](./SETUP_WIZARD.md).
+There is a Setup Wizard in the Kit which allows easy editing of connection references and environment variables as well as turning on cloud flows. After deploying the Kit from either AppSource or GitHub, you may access the Setup Wizard from the Home-page of the Copilot Agent Kit. Please see additional information [here](./SETUP_WIZARD.md).
 
 - [Prerequisites](./PREREQUISITES.md)
 - [Installation instructions](./INSTALLATION_INSTRUCTIONS.md)
@@ -138,7 +138,7 @@ Stay up to date with our releases by **subscribing** to them:
 
 # About this GitHub repo
 
-The Power CAT Copilot Studio Kit GitHub Repo contains the source, releases, issues and backlog items of all components that are part of the Power CAT Copilot Studio Kit.
+The Copilot Agent Kit GitHub Repo contains the source, releases, issues and backlog items of all components that are part of the Copilot Agent Kit.
 
 ## Submit a feature request
 

--- a/RUN_TESTS.md
+++ b/RUN_TESTS.md
@@ -1,10 +1,10 @@
-# Running tests in Power CAT Copilot Studio Kit
+# Running tests in Copilot Agent Kit
 
 **Test Runs** allow to execute multiple **Tests** contained in a single test set against a specific **Agent Configuration**.
 
 ## Creating a Test Run
 
-1. Open the Power CAT Copilot Studio Kit application (as seen in [installation instructions](./INSTALLATION_INSTRUCTIONS.md#access-the-copilot-studio-accelerator-app))
+1. Open the Copilot Agent Kit application (as seen in [installation instructions](./INSTALLATION_INSTRUCTIONS.md#access-the-copilot-studio-accelerator-app))
 2. Navigate to **Test Runs**.
 3. Create a **New** Agent Test Run record.
 4. Provide a **Name**.

--- a/RubricRefinement/01-rubrics-refinement-overview.md
+++ b/RubricRefinement/01-rubrics-refinement-overview.md
@@ -2,7 +2,7 @@
 
 ## What is Rubrics Refinement?
 
-Rubrics Refinement is a powerful capability in Copilot Studio Kit that enables you to create, test, and iteratively improve reusable evaluation standards (rubrics) for AI-generated responses. This feature helps ensure that AI grading of your agent's responses aligns with human judgment and organizational quality standards.
+Rubrics Refinement is a powerful capability in Copilot Agent Kit that enables you to create, test, and iteratively improve reusable evaluation standards (rubrics) for AI-generated responses. This feature helps ensure that AI grading of your agent's responses aligns with human judgment and organizational quality standards.
 
 ## The Problem It Solves
 
@@ -64,7 +64,7 @@ Response optimizationâ€”actually improving the quality of your agent's answersâ€
 
 ## Two Modes of Rubric Usage
 
-Rubrics in Copilot Studio Kit serve two distinct purposes:
+Rubrics in Copilot Agent Kit serve two distinct purposes:
 
 ### 1. Testing Mode (Test Case Level)
 - **Purpose**: Regular test automation with custom grading criteria

--- a/RubricRefinement/02-rubric-management.md
+++ b/RubricRefinement/02-rubric-management.md
@@ -14,7 +14,7 @@ A rubric consists of three main components:
 
 ## Accessing Rubric Management
 
-Navigate to the Rubric Management interface in Copilot Studio Kit to view and manage your rubrics.
+Navigate to the Rubric Management interface in Copilot Agent Kit to view and manage your rubrics.
 
 ![Rubric List View](RubricManagementListView.png)
 

--- a/RubricRefinement/03-using-rubrics-in-tests.md
+++ b/RubricRefinement/03-using-rubrics-in-tests.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Rubrics can be used in two distinct modes within Copilot Studio Kit test automation. Understanding the difference between these modes is essential for effective use of the Rubrics Refinement feature.
+Rubrics can be used in two distinct modes within Copilot Agent Kit test automation. Understanding the difference between these modes is essential for effective use of the Rubrics Refinement feature.
 
 ## Two Modes of Rubric Usage
 
@@ -21,10 +21,10 @@ Rubrics can be used in two distinct modes within Copilot Studio Kit test automat
 
 ### When to Use Testing Mode
 
-Use test case level rubrics in Copilot Studio Kit when you:
+Use test case level rubrics in Copilot Agent Kit when you:
 - Have a refined, trustworthy custom rubric ready for regular use
 - Want to automate quality checks for Generative Answer responses in existing test sets
-- Need custom evaluation criteria beyond standard validation in Copilot Studio Kit
+- Need custom evaluation criteria beyond standard validation in Copilot Agent Kit
 
 ### How to Assign a Rubric at Test Case Level
 

--- a/RubricRefinement/06-reference.md
+++ b/RubricRefinement/06-reference.md
@@ -270,7 +270,7 @@ Using a rubric at the individual test case level for regular quality assurance. 
 Using a rubric at the test run level specifically for iterative rubric refinement. AI provides grade + detailed rationale. Non-Generative Answer test types are skipped. Goal is to minimize misalignment between AI and human grades.
 
 ### Generative Answer Test (GA Test)
-A test type in Copilot Studio Kit where the agent generates natural-language responses (using generative orchestration) that are evaluated against provided validation instructions or a rubric.
+A test type in Copilot Agent Kit where the agent generates natural-language responses (using generative orchestration) that are evaluated against provided validation instructions or a rubric.
 
 ### Test Set
 A collection of one or more test cases executed together. In refinement mode, the same rubric applies to all Generative Answer test cases in the set.
@@ -321,10 +321,10 @@ A focused interface for reviewing and grading individual test cases with longer 
 Text-based instructions used in standard Generative Answer tests to specify what makes a response acceptable. Mutually exclusive with rubric-based grading—when a rubric is selected, validation instructions are hidden or ignored.
 
 ### Custom Grader (Copilot Studio)
-A future Copilot Studio feature that will allow makers to define custom evaluation logic for copilot responses. Rubrics refined in Copilot Studio Kit are designed to be compatible with this system (future integration).
+A future Copilot Studio feature that will allow makers to define custom evaluation logic for copilot responses. Rubrics refined in Copilot Agent Kit are designed to be compatible with this system (future integration).
 
 ### Maker
-A user of Copilot Studio Kit who creates, tests, and manages copilots and evaluation rubrics. In the context of rubric refinement, the maker provides human judgments that serve as the evaluation standard.
+A user of Copilot Agent Kit who creates, tests, and manages copilots and evaluation rubrics. In the context of rubric refinement, the maker provides human judgments that serve as the evaluation standard.
 
 ### Agent
 The copilot or AI assistant being tested. In rubric refinement, the agent generates responses that are evaluated by both AI judges and human makers.

--- a/SECURITY_ROLES.md
+++ b/SECURITY_ROLES.md
@@ -14,9 +14,9 @@ The Copilot Agent Kit includes two primary security roles designed to support di
 > [!NOTE]
 > The following legacy security roles have been deprecated and should no longer be used. Please migrate users to the new **CAK - Administrator** or **CAK - Maker** roles:
 >
-> - Copilot Agent Kit - Administrator - Deprecated
-> - Copilot Agent Kit - Configurator - Deprecated
-> - Copilot Agent Kit - Tester/KPI Viewer - Deprecated
+> - Copilot Studio Kit - Administrator - Deprecated
+> - Copilot Studio Kit - Configurator - Deprecated
+> - Copilot Studio Kit - Tester/KPI Viewer - Deprecated
 
 ---
 

--- a/SECURITY_ROLES.md
+++ b/SECURITY_ROLES.md
@@ -1,22 +1,22 @@
 # Security Roles
 
-This document describes the security roles available in the Copilot Studio Kit (CSK) and their associated table permissions.
+This document describes the security roles available in the Copilot Agent Kit (CAK) and their associated table permissions.
 
 ## Overview
 
-The Copilot Studio Kit includes two primary security roles designed to support different user personas:
+The Copilot Agent Kit includes two primary security roles designed to support different user personas:
 
 | Role                    | Description                                                                                                                                                                                                                                                                                                     |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **CSK - Administrator** | Full administrative access to all CSK features. Intended for solution administrators who need to configure, manage, and maintain the entire Copilot Studio Kit. Administrators have Organization-level access to most tables, allowing them to view and manage all records across the organization.             |
-| **CSK - Maker**         | Limited access designed for users who create and test agents. Makers typically have User-level access, allowing them to work with their own records while having read access to shared configuration data. This role is suitable for developers and testers who need to build and validate agent functionality. |
+| **CAK - Administrator** | Full administrative access to all CAK features. Intended for solution administrators who need to configure, manage, and maintain the entire Copilot Agent Kit. Administrators have Organization-level access to most tables, allowing them to view and manage all records across the organization.             |
+| **CAK - Maker**         | Limited access designed for users who create and test agents. Makers typically have User-level access, allowing them to work with their own records while having read access to shared configuration data. This role is suitable for developers and testers who need to build and validate agent functionality. |
 
 > [!NOTE]
-> The following legacy security roles have been deprecated and should no longer be used. Please migrate users to the new **CSK - Administrator** or **CSK - Maker** roles:
+> The following legacy security roles have been deprecated and should no longer be used. Please migrate users to the new **CAK - Administrator** or **CAK - Maker** roles:
 >
-> - Copilot Studio Kit - Administrator - Deprecated
-> - Copilot Studio Kit - Configurator - Deprecated
-> - Copilot Studio Kit - Tester/KPI Viewer - Deprecated
+> - Copilot Agent Kit - Administrator - Deprecated
+> - Copilot Agent Kit - Configurator - Deprecated
+> - Copilot Agent Kit - Tester/KPI Viewer - Deprecated
 
 ---
 
@@ -63,9 +63,9 @@ The Copilot Studio Kit includes two primary security roles designed to support d
 
 ---
 
-## CSK - Administrator Role
+## CAK - Administrator Role
 
-The Administrator role provides comprehensive access to manage all aspects of the Copilot Studio Kit.
+The Administrator role provides comprehensive access to manage all aspects of the Copilot Agent Kit.
 
 **Legend:** 🟢 Organization | 🔵 User | 🚫 None
 
@@ -424,7 +424,7 @@ The Administrator role provides comprehensive access to manage all aspects of th
 <td>🟢</td>
 </tr>
 <tr>
-<td>Copilot Studio Kit Logs</td>
+<td>Copilot Agent Kit Logs</td>
 <td>🟢</td>
 <td>🟢</td>
 <td>🟢</td>
@@ -438,7 +438,7 @@ The Administrator role provides comprehensive access to manage all aspects of th
 
 ---
 
-## CSK - Maker Role
+## CAK - Maker Role
 
 The Maker role provides access for users who build and test agents, with limited administrative capabilities.
 
@@ -799,7 +799,7 @@ The Maker role provides access for users who build and test agents, with limited
 <td>🟢</td>
 </tr>
 <tr>
-<td>Copilot Studio Kit Logs</td>
+<td>Copilot Agent Kit Logs</td>
 <td>🔵</td>
 <td>🔵</td>
 <td>🔵</td>

--- a/SETUP_USERS_AND_TEAMS.md
+++ b/SETUP_USERS_AND_TEAMS.md
@@ -1,6 +1,6 @@
-# Setup users and teams in Power CAT Copilot Studio Kit
+# Setup users and teams in Copilot Agent Kit
 
-After completing the installation of Power CAT Copilot Studio Kit, you can grant security roles to your users so that they can configure new agents and tests.
+After completing the installation of Copilot Agent Kit, you can grant security roles to your users so that they can configure new agents and tests.
 
 It's a best practice to security assign roles via Entra ID group and team memberships, but you can also assign them manually and individually to users.
 
@@ -10,7 +10,7 @@ For more information on security roles, go to the [Security Roles](https://githu
 
 1. Go to the [Power Platform Admin Center](https://admin.powerplatform.microsoft.com/).
 2. Navigate to **Environments**
-3. Select the environments where you have installed the Power CAT Copilot Studio Kit on.
+3. Select the environments where you have installed the Copilot Agent Kit on.
 
 ## Assign security roles to users
 
@@ -25,7 +25,7 @@ That way users can inherit security roles automatically, simply by being member 
 4. Set the required properties, and in **Team type**, select either **Microsoft Entra ID Security Group** or **Microsoft Entra ID Office Group**.
 5. Search and select the desired **group**.
 6. Select **Next**
-7. Select the desired Power CAT Copilot Studio Kit **security role**.
+7. Select the desired Copilot Agent Kit **security role**.
 8. **Save**
 
 > [!NOTE]
@@ -41,7 +41,7 @@ That way users can inherit security roles automatically, simply by being member 
 3. If the user isn't present in the list, select** Add user** and add them.
 4. Select the **user**.
 5. Select **Manage roles**.
-6. Select the desired Power CAT Copilot Studio Kit **security role**.
+6. Select the desired Copilot Agent Kit **security role**.
 7. **Save**
 
 > [!NOTE]
@@ -66,7 +66,7 @@ _Note: if you don't store secrets in these columns, this step isn't required._
 1. From the **environment** overview page
 2. Go **Settings**
 3. Under **Users + permissions**, select **Column security profiles**
-4. Select **Power CAT Copilot Studio Kit Column Security Profile**
+4. Select **Copilot Agent Kit Column Security Profile**
 5. Navigate to the **Teams** or **Users** tab and add the relevant **teams** and/or **users** that should have access to these secured columns.
 
 ## Next step

--- a/SETUP_WIZARD.md
+++ b/SETUP_WIZARD.md
@@ -1,7 +1,7 @@
 # Setup wizard
 ## Overview
 
-Setup Wizard can be accessed from the home page of the Copilot Studio Kit. Setup Wizard provides a guided flow through most of the post deployment steps where pre-requisites are checked, connection references and environment variables can be set, and cloud flows can be turned on. You can move forward and backward between steps by clicking Back and Next buttons.
+Setup Wizard can be accessed from the home page of the Copilot Agent Kit. Setup Wizard provides a guided flow through most of the post deployment steps where pre-requisites are checked, connection references and environment variables can be set, and cloud flows can be turned on. You can move forward and backward between steps by clicking Back and Next buttons.
 
 ![image](https://github.com/user-attachments/assets/db4095ff-9f35-4458-b2e5-b2d41e3ca7b9)
 
@@ -19,13 +19,13 @@ The connection references step lists all the connection references used by the K
 
 ## Environment Variables
 
-The environment variables step lists all the environment variables that are used in the Copilot Studio Kit, with descriptions how they are used, how they should be set and when. Setting the environment variables from this view is also possible.
+The environment variables step lists all the environment variables that are used in the Copilot Agent Kit, with descriptions how they are used, how they should be set and when. Setting the environment variables from this view is also possible.
 
 ![image](https://github.com/user-attachments/assets/e0f6031b-17de-48af-843a-a773e7e66375)
 
 ## Flow activation
 
-Flow activation view allows user to view the current status of Copilot Studio Kit flows and they can be easily turned on from this view as well. Some of the flows cannot be turned on before setting related connection references. Flows are named so that the feature they are used in can easily be seen as the prefix. Users only need to enable the flows for the features they are planning to use.
+Flow activation view allows user to view the current status of Copilot Agent Kit flows and they can be easily turned on from this view as well. Some of the flows cannot be turned on before setting related connection references. Flows are named so that the feature they are used in can easily be seen as the prefix. Users only need to enable the flows for the features they are planning to use.
 
 ![image](https://github.com/user-attachments/assets/fdbc6ab7-6512-4ab1-ae8f-965cfa2cb5ca)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,11 +15,11 @@ If your bug or feature request has already been reported, join the conversation 
 - 👍: upvote
 - 👎: downvote
 
-## Support for the Power CAT Copilot Studio Kit
+## Support for the Copilot Agent Kit
 
-Although the underlying features and components used to build the Power CAT Copilot Studio Kit are fully supported (such as Power Apps, Power Automate, Dataverse, Copilot Studio endpoints etc.), the accelerator itself represents an example implementation of these features. Our customers, partners, and community can use and customize these features to implement capabilities in their organizations.
+Although the underlying features and components used to build the Copilot Agent Kit are fully supported (such as Power Apps, Power Automate, Dataverse, Copilot Studio endpoints etc.), the accelerator itself represents an example implementation of these features. Our customers, partners, and community can use and customize these features to implement capabilities in their organizations.
 
 If you face issues with:
 
-- **Using the Power CAT Copilot Studio Kit**: Report your issue here https://github.com/microsoft/Powercat-Copilotstudio-Accelerator/issues. Microsoft Support won't help you with issues related to the accelerator, but they will help with related, underlying platform and feature issues.
+- **Using the Copilot Agent Kit**: Report your issue here https://github.com/microsoft/Powercat-Copilotstudio-Accelerator/issues. Microsoft Support won't help you with issues related to the accelerator, but they will help with related, underlying platform and feature issues.
 - **The core Microsoft features**: Use your standard channel to contact Microsoft Support: [Get Help + Support](https://learn.microsoft.com/en-us/power-platform/admin/get-help-support)

--- a/TECHDETAILS.md
+++ b/TECHDETAILS.md
@@ -1,4 +1,4 @@
-# Technical information about Copilot Studio Kit
+# Technical information about Copilot Agent Kit
 ## Environment variables
 
 | Name | Description  | Notes |
@@ -13,9 +13,9 @@
 
 | Name | Description  | Notes |
 | :-- | :-- | :-- |
-| Copilot Studio Kit - Dataverse | Microsoft Dataverse connection reference for Copilot Studio Kit | Required |
-| Copilot Studio Kit - Power Platform for Admins | This connection reference is used to get a list of environments in Agent Inventory feature | Required for Agent Inventory |
-| Copilot Studio Kit - SharePoint | This connection reference is used with SharePoint synchronization | Required for SharePoint synchronization |
+| Copilot Agent Kit - Dataverse | Microsoft Dataverse connection reference for Copilot Agent Kit | Required |
+| Copilot Agent Kit - Power Platform for Admins | This connection reference is used to get a list of environments in Agent Inventory feature | Required for Agent Inventory |
+| Copilot Agent Kit - SharePoint | This connection reference is used with SharePoint synchronization | Required for SharePoint synchronization |
 
 ## Connectors used (for DLP configuration purposes)
 

--- a/TESTING_CAPABILITIES.md
+++ b/TESTING_CAPABILITIES.md
@@ -1,5 +1,5 @@
 ## Testing capabilities  
-The Power CAT Copilot Studio Kit is a user-friendly application that empowers makers to configure agents and test sets. It has native capabilities such as Excel export or import for bulk creation and updates.
+The Copilot Agent Kit is a user-friendly application that empowers makers to configure agents and test sets. It has native capabilities such as Excel export or import for bulk creation and updates.
 
 By running individual tests against the Copilot Studio APIs (Direct Line), the agent responses are evaluated against expected results.
 To further enrich results, additional data points can be retrieved from Azure Application Insights and from Dataverse, by analyzing Conversation Transcript records (to get the exact triggered topic name, intent recognition scores, etc.).

--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -1,4 +1,4 @@
-# Troubleshoot errors in Power CAT Copilot Studio Kit
+# Troubleshoot errors in Copilot Agent Kit
 ## AppForbidden or other DLP errors
 
 Ensure that you have the following connectors allowed in the DLP policy
@@ -9,16 +9,16 @@ Ensure that you have the following connectors allowed in the DLP policy
 
 Typically, two app registrations need to be created for the end user authentication:
 
-**KitAuthApp** – Used in Copilot Studio Kit agent configurations
+**KitAuthApp** – Used in Copilot Agent Kit agent configurations
 
 **CopilotStudioAuthApp**  - Used in Copilot Studio, linked to KitAuthApp
 
 #### General checklist
-* Ensure that the custom agent (Copilot Studio) and the Copilot Studio Kit are on the same tenant
-* Before enabling end user authentication, make sure authentication is disabled on both the custom agent and agent configuration in Copilot Studio Kit and run a simple test to verify that the connectivity works
+* Ensure that the custom agent (Copilot Studio) and the Copilot Agent Kit are on the same tenant
+* Before enabling end user authentication, make sure authentication is disabled on both the custom agent and agent configuration in Copilot Agent Kit and run a simple test to verify that the connectivity works
 
 #### Checklist for KitAuthApp
-* In Azure Portal, Authentication, verify that Web Redirect URI has the Dataverse URI where Copilot Studio Kit is deployed to
+* In Azure Portal, Authentication, verify that Web Redirect URI has the Dataverse URI where Copilot Agent Kit is deployed to
 * Verify that supported account types is “Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)”
 * In API permissions, verify that User.Read permission is in the list, delegated and has admin consent granted
 * Verify that client secret is created and that secret is in the Agent Configuration (User Authentication->Client Secret)
@@ -48,7 +48,7 @@ Typically, two app registrations need to be created for the end user authenticat
 *	Ensure that test pane works
 *	Ensure that demo site works (including login)
 
-#### Checklist for the agent configuration in Copilot Studio Kit
+#### Checklist for the agent configuration in Copilot Agent Kit
 * Ensure token endpoint is correctly set (copied from mobile channel) OR channel security is set and the correct secret is configured
 * Ensure user authentication is set to “Entra ID v2”
 * Ensure that the Client ID is the client id of KitAuthApp

--- a/agent-review-pipeline/README.md
+++ b/agent-review-pipeline/README.md
@@ -1,6 +1,6 @@
 # Agent Review Pipeline
 
-Part of the **Copilot Studio Kit** - a set of tools for managing, monitoring, and governing Copilot Studio agents at scale.
+Part of the **Copilot Agent Kit** - a set of tools for managing, monitoring, and governing Copilot Studio agents at scale.
 
 ## What is the Agent Review Tool?
 
@@ -38,4 +38,4 @@ Automated quality gate for agents deployed via Power Platform Pipelines. When a 
 
 ## License
 
-Part of the [Copilot Studio Kit](https://github.com/Ramakrishnan24689/Power-CAT-Copilot-Studio-Kit).
+Part of the [Copilot Agent Kit](https://github.com/Ramakrishnan24689/Power-CAT-Copilot-Studio-Kit).

--- a/agent-review-pipeline/docs/Agent Review Pipeline - CICD Setup Guide.md
+++ b/agent-review-pipeline/docs/Agent Review Pipeline - CICD Setup Guide.md
@@ -39,7 +39,7 @@ Pipeline approved (score ≥ threshold) or rejected
 
 > ⚠️ **Custom host is required.** The pre-deployment flow must run in the pipeline host environment. With Platform host, that environment is managed by Microsoft and you cannot deploy flows there. You need a [custom host](https://learn.microsoft.com/en-us/power-platform/alm/custom-host-pipelines) so the flow, AI prompts, and extensibility actions all live in an environment you control. See [Extend pipelines - Triggers](https://learn.microsoft.com/en-us/power-platform/alm/extend-pipelines#triggers): *"Triggers are available in Power Automate cloud flows within the pipelines host environment."*
 
-> **Note:** The Copilot Studio Kit is NOT required. The pipeline solution ships its own AI prompts and can be installed in any custom host environment independently.
+> **Note:** The Copilot Agent Kit is NOT required. The pipeline solution ships its own AI prompts and can be installed in any custom host environment independently.
 
 ---
 
@@ -63,7 +63,7 @@ Generate a client secret. Save these three values:
 
 ### 2. Set Up GitHub Repo
 
-Clone or fork the [Agent Review Pipeline](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/tree/main/agent-review-pipeline) folder from the Copilot Studio Kit repository into your own repo. The folder contains everything needed to run the action:
+Clone or fork the [Agent Review Pipeline](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/tree/main/agent-review-pipeline) folder from the Copilot Agent Kit repository into your own repo. The folder contains everything needed to run the action:
 
 ```
 your-repo/
@@ -104,7 +104,7 @@ Copy the token.
 
 ### 4. Import Solution
 
-Download the **Agent Review Pipeline** managed solution (`AgentReviewPipeline_managed.zip`) from the [Copilot Studio Kit GitHub releases](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/releases) page, then import it into the **pipeline host environment**.
+Download the **Agent Review Pipeline** managed solution (`AgentReviewPipeline_managed.zip`) from the [Copilot Agent Kit GitHub releases](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit/releases) page, then import it into the **pipeline host environment**.
 
 During import, the wizard will prompt for environment variable values and connection references. Fill in:
 


### PR DESCRIPTION
This pull request updates documentation across multiple files to rename the product from "Copilot Studio Kit" (CSK) to "Copilot Agent Kit" (CAK). It also updates related terminology, security role names, and references throughout the docs to ensure consistency with the new product name.

Key changes include:

**Product naming and branding updates:**
- Replaced all references to "Copilot Studio Kit" with "Copilot Agent Kit" in documentation files, section headings, and image captions. [[1]](diffhunk://#diff-63a545f2b77c3bd404bbb34880da1f8596379c2811d8f219555e5422f6e0c665L4-R4) [[2]](diffhunk://#diff-688d2d8a2e061eaa6376e3174d8893906117882244eb02fb7cb4f6e9a4fa859fL5-R5) [[3]](diffhunk://#diff-c115821ff7c5e42ccd92b5d661fda244a98a33e4fc9a2ba53f19c086daf2c7a0L3-R3) [[4]](diffhunk://#diff-c115821ff7c5e42ccd92b5d661fda244a98a33e4fc9a2ba53f19c086daf2c7a0L40-R40) [[5]](diffhunk://#diff-c115821ff7c5e42ccd92b5d661fda244a98a33e4fc9a2ba53f19c086daf2c7a0L89-R93) [[6]](diffhunk://#diff-c115821ff7c5e42ccd92b5d661fda244a98a33e4fc9a2ba53f19c086daf2c7a0L354-R356) [[7]](diffhunk://#diff-c115821ff7c5e42ccd92b5d661fda244a98a33e4fc9a2ba53f19c086daf2c7a0L374-R374) [[8]](diffhunk://#diff-c115821ff7c5e42ccd92b5d661fda244a98a33e4fc9a2ba53f19c086daf2c7a0L434-R434) [[9]](diffhunk://#diff-70b57c6d2f0a6d046db4dcff6526ea00081a62bd5ec30e042afeaddb2cd58269L6-R6)
- Updated repository and solution names to align with the new product branding, including links and installation instructions. [[1]](diffhunk://#diff-fdad4fba257e7d35f8cd30a4c8af3588879b676e6da84d1de4efc7833d59764dL656-R656) [[2]](diffhunk://#diff-688d2d8a2e061eaa6376e3174d8893906117882244eb02fb7cb4f6e9a4fa859fL41-R46) [[3]](diffhunk://#diff-688d2d8a2e061eaa6376e3174d8893906117882244eb02fb7cb4f6e9a4fa859fL79-R91)

**Security role and permission terminology:**
- Changed all security role references from "CSK - Administrator"/"CSK - Maker"/"CSK - Admin" to "CAK - Administrator"/"CAK - Maker"/"CAK - Admin" across the documentation. [[1]](diffhunk://#diff-bf8e03ef8a3784f93b4cda66bd6602f3230d5b7393d0bd1a02f1eb8ae5206405L81-R81) [[2]](diffhunk://#diff-bf8e03ef8a3784f93b4cda66bd6602f3230d5b7393d0bd1a02f1eb8ae5206405L448-R448) [[3]](diffhunk://#diff-fcc7ccf7cb52702685bad86d32095ead4382d6e2a2bb5bc1f9199b0926eb1828L63-R68) [[4]](diffhunk://#diff-c115821ff7c5e42ccd92b5d661fda244a98a33e4fc9a2ba53f19c086daf2c7a0L12-R22) [[5]](diffhunk://#diff-c115821ff7c5e42ccd92b5d661fda244a98a33e4fc9a2ba53f19c086daf2c7a0L263-R263)

**Feature and connector references:**
- Updated feature, connector, and environment variable names to use "Copilot Agent Kit" instead of "Copilot Studio Kit" for clarity and consistency. [[1]](diffhunk://#diff-688d2d8a2e061eaa6376e3174d8893906117882244eb02fb7cb4f6e9a4fa859fL25-R25) [[2]](diffhunk://#diff-688d2d8a2e061eaa6376e3174d8893906117882244eb02fb7cb4f6e9a4fa859fL64-R64) [[3]](diffhunk://#diff-688d2d8a2e061eaa6376e3174d8893906117882244eb02fb7cb4f6e9a4fa859fL79-R91)

**Test automation and other descriptive updates:**
- Adjusted descriptions and notes to reference "Copilot Agent Kit" for test automation and other feature documentation. [[1]](diffhunk://#diff-70b57c6d2f0a6d046db4dcff6526ea00081a62bd5ec30e042afeaddb2cd58269L166-R166) [[2]](diffhunk://#diff-fcc7ccf7cb52702685bad86d32095ead4382d6e2a2bb5bc1f9199b0926eb1828L563-R563)

These changes ensure that all documentation accurately reflects the new product name and associated terminology, reducing confusion for users and aligning with current branding.