### PR TITLE
fix: postpone APAC office hours by one hour

### DIFF
--- a/OFFICEHOURS.md
+++ b/OFFICEHOURS.md
@@ -5,7 +5,7 @@
 > Starting May 13, 2026, Copilot Agent Kit Office Hours will move to an every-other-week schedule.
 > The format is also changing: each session will now include updates and demos from the team, including highlights of new features and walkthroughs showing how to configure features or accomplish more complex scenarios with existing capabilities.
 > * US-friendly slot: 10:05 AM Pacific Time (PT)
-> * APAC-friendly slot: 9:05 PM Pacific Time (PT) (next-day morning in IST)
+> * APAC-friendly slot: 11:35 AM India Standard Time (IST), which is 10:05 PM Pacific Time (PT) the previous day
 
 During office hours we will have Copilot Agent Kit team present and part of the meeting is dedicated for updates from the team, and demonstration of new features.
 

--- a/docs/calendar/CopilotStudioKitOfficeHours-APAC.ics
+++ b/docs/calendar/CopilotStudioKitOfficeHours-APAC.ics
@@ -6,15 +6,15 @@ METHOD:PUBLISH
 
 BEGIN:VEVENT
 UID:officehours-apac-2025
-DTSTAMP:20260513T165000Z
-LAST-MODIFIED:20260513T165000Z
-SEQUENCE:1
+DTSTAMP:20260825T185000Z
+LAST-MODIFIED:20260825T185000Z
+SEQUENCE:2
 SUMMARY:Copilot Studio Kit - Public Office Hours - APAC Slot
 DESCRIPTION:Copilot Studio Kit – Public Office Hours – APAC Slot.\n\nThis meeting allows Copilot Studio Kit users to ask questions and provide feedback.\n\nMeeting Details:\n- Join: https://teams.microsoft.com/meet/27015291501632?p=Me5sBkkLPzU1yZvyTK\n- Meeting ID: 270 152 915 016 32\n- Passcode: fz97hD63\n- Dial-in: +1 323-849-4874,,396344102# (Conference ID: 396 344 102#)\n
 LOCATION:https://teams.microsoft.com/meet/27015291501632?p=Me5sBkkLPzU1yZvyTK
 
-DTSTART:20251204T050500Z
-DTEND:20251204T055500Z
+DTSTART:20251204T060500Z
+DTEND:20251204T065500Z
 
 RRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=TH
 TRANSP:OPAQUE


### PR DESCRIPTION
Move the recurring APAC session from 05:05 UTC to 06:05 UTC (10:35 AM to 11:35 AM IST), keeping the 50-minute duration.

Bump SEQUENCE and refresh DTSTAMP/LAST-MODIFIED so calendar clients accept the update. Update the slot time stated in OFFICEHOURS.md, leading with IST since that is the target audience.

