### PR TITLE
docs: add Power Automate Management and Agents (preview) to connector…

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -69,6 +69,11 @@ Every connector shipped in the Copilot Agent Kit solution must be allowed by the
 | [Power Apps for Makers](https://learn.microsoft.com/connectors/powerappsforappmakers/) | Setup Wizard, Power Shield |
 | [HTTP with Microsoft Entra ID (preauthorized)](https://learn.microsoft.com/connectors/webcontents/) | Power Shield, Usage Metrics |
 | [Microsoft Copilot Studio](https://learn.microsoft.com/connectors/microsoftcopilotstudio/) | Test Automation and Pipeline |
+| [Power Automate Management](https://learn.microsoft.com/connectors/flowmanagement/) | Setup Wizard / Installer, Agent Review Tool |
+| Agents (preview) | Agent Review Tool |
+
+> [!NOTE]
+> The **Agents** connector is a preview connector (`shared_agentnode`) used by the Agent Review Tool workflow. It cannot be configured through the standard connection-reference screen during solution import — skip it during import and use the **Setup Wizard / Installer** to complete the Agent Review setup. See the [Agent Review Tool reference guide](./AGENTREVIEWTOOL_REFERENCE_GUIDE.md#set-up-agent-review-with-the-setup-wizard-and-installer) for details.
 
 ## Next step
 [Installation instructions](./INSTALLATION_INSTRUCTIONS.md)


### PR DESCRIPTION
… requirements

Adds two missing connectors to the PREREQUISITES.md connector requirements table:
- Power Automate Management (shared_flowmanagement) used by Setup Wizard / Installer
- Agents preview (shared_agentnode) used by Agent Review Tool

Includes a note explaining that the Agents connector cannot be configured during solution import and should be set up via the Installer.

Fixes #846